### PR TITLE
Hide sidebar on public pages and sync header with nav

### DIFF
--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -4,7 +4,7 @@ import { SiteHeader } from "@/components/site-header"
 export default function ContactsPage() {
   return (
     <SidebarInset>
-      <SiteHeader />
+      <SiteHeader title="Contacts" />
       <div className="p-4">
         <h1 className="text-2xl font-bold">Contacts</h1>
       </div>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,7 +6,7 @@ import { ChartAreaInteractive } from "@/components/chart-area-interactive"
 export default function DashboardPage() {
   return (
     <SidebarInset>
-      <SiteHeader />
+      <SiteHeader title="Dashboard" />
       <div className="space-y-4 p-4">
         <SectionCards />
         <ChartAreaInteractive />

--- a/src/app/finance/page.tsx
+++ b/src/app/finance/page.tsx
@@ -4,7 +4,7 @@ import { SiteHeader } from "@/components/site-header"
 export default function FinancePage() {
   return (
     <SidebarInset>
-      <SiteHeader />
+      <SiteHeader title="Finance" />
       <div className="p-4">
         <h1 className="text-2xl font-bold">Finance</h1>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,7 @@
 import "./globals.css"
 import type { Metadata } from "next"
 import { ThemeProvider } from "@/components/theme-provider"
-import { SidebarProvider } from "@/components/ui/sidebar"
-import { AppSidebar } from "@/components/app-sidebar"
+import { LayoutWrapper } from "@/components/layout-wrapper"
 
 export const metadata: Metadata = {
   title: "Coach House CRM",
@@ -13,10 +12,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <body className="font-sans antialiased">
         <ThemeProvider>
-          <SidebarProvider>
-            <AppSidebar variant="inset" />
-            {children}
-          </SidebarProvider>
+          <LayoutWrapper>{children}</LayoutWrapper>
         </ThemeProvider>
       </body>
     </html>

--- a/src/app/marketing/page.tsx
+++ b/src/app/marketing/page.tsx
@@ -4,7 +4,7 @@ import { SiteHeader } from "@/components/site-header"
 export default function MarketingPage() {
   return (
     <SidebarInset>
-      <SiteHeader />
+      <SiteHeader title="Marketing" />
       <div className="p-4">
         <h1 className="text-2xl font-bold">Marketing</h1>
       </div>

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -4,7 +4,7 @@ import { SiteHeader } from "@/components/site-header"
 export default function ReportsPage() {
   return (
     <SidebarInset>
-      <SiteHeader />
+      <SiteHeader title="Reports" />
       <div className="p-4">
         <h1 className="text-2xl font-bold">Reports</h1>
       </div>

--- a/src/app/segments/page.tsx
+++ b/src/app/segments/page.tsx
@@ -4,7 +4,7 @@ import { SiteHeader } from "@/components/site-header"
 export default function SegmentsPage() {
   return (
     <SidebarInset>
-      <SiteHeader />
+      <SiteHeader title="Segments" />
       <div className="p-4">
         <h1 className="text-2xl font-bold">Segments</h1>
       </div>

--- a/src/app/sequences/page.tsx
+++ b/src/app/sequences/page.tsx
@@ -4,7 +4,7 @@ import { SiteHeader } from "@/components/site-header"
 export default function SequencesPage() {
   return (
     <SidebarInset>
-      <SiteHeader />
+      <SiteHeader title="Sequences" />
       <div className="p-4">
         <h1 className="text-2xl font-bold">Sequences</h1>
       </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -4,7 +4,7 @@ import { SiteHeader } from "@/components/site-header"
 export default function SettingsPage() {
   return (
     <SidebarInset>
-      <SiteHeader />
+      <SiteHeader title="Settings" />
       <div className="p-4">
         <h1 className="text-2xl font-bold">Settings</h1>
       </div>

--- a/src/components/layout-wrapper.tsx
+++ b/src/components/layout-wrapper.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { usePathname } from 'next/navigation'
+import { SidebarProvider } from '@/components/ui/sidebar'
+import { AppSidebar } from '@/components/app-sidebar'
+
+export function LayoutWrapper({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  const showSidebar = pathname !== '/' && pathname !== '/login'
+
+  if (!showSidebar) {
+    return <>{children}</>
+  }
+
+  return (
+    <SidebarProvider>
+      <div className="flex h-dvh w-full overflow-hidden">
+        <AppSidebar variant="inset" />
+        {children}
+      </div>
+    </SidebarProvider>
+  )
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,29 +1,13 @@
-import { Button } from "@/components/ui/button"
 import { Separator } from "@/components/ui/separator"
 import { SidebarTrigger } from "@/components/ui/sidebar"
 
-export function SiteHeader() {
+export function SiteHeader({ title }: { title: string }) {
   return (
     <header className="flex h-(--header-height) shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-(--header-height)">
       <div className="flex w-full items-center gap-1 px-4 lg:gap-2 lg:px-6">
         <SidebarTrigger className="-ml-1" />
-        <Separator
-          orientation="vertical"
-          className="mx-2 data-[orientation=vertical]:h-4"
-        />
-        <h1 className="text-base font-medium">Documents</h1>
-        <div className="ml-auto flex items-center gap-2">
-          <Button variant="ghost" asChild size="sm" className="hidden sm:flex">
-            <a
-              href="https://github.com/shadcn-ui/ui/tree/main/apps/v4/app/(examples)/dashboard"
-              rel="noopener noreferrer"
-              target="_blank"
-              className="dark:text-foreground"
-            >
-              GitHub
-            </a>
-          </Button>
-        </div>
+        <Separator orientation="vertical" className="mx-2 data-[orientation=vertical]:h-4" />
+        <h1 className="text-base font-medium">{title}</h1>
       </div>
     </header>
   )

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -309,7 +309,7 @@ function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
     <main
       data-slot="sidebar-inset"
       className={cn(
-        "bg-background relative flex w-full flex-1 flex-col",
+        "bg-background relative flex h-full w-full flex-1 flex-col overflow-y-auto",
         "md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
         className
       )}


### PR DESCRIPTION
## Summary
- Hide sidebar on the home and login routes, only show it for authenticated pages
- Fix scroll behavior so only the inset content scrolls
- Display dynamic page titles in the site header and remove placeholder GitHub link

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4c385ce40832d9aeb7788bab048d8