### PR TITLE
fix: add missing React import in root layout

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import "./globals.css"
+import React from "react"
 import type { Metadata } from "next"
 import { ThemeProvider } from "@/components/theme-provider"
 import { LayoutWrapper } from "@/components/layout-wrapper"


### PR DESCRIPTION
## Summary
- add React import in RootLayout to avoid runtime reference errors

## Testing
- `npm run lint`
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: middleware.ts:14:9 No overload matches this call)


------
https://chatgpt.com/codex/tasks/task_e_68a4cdb802c4832da224e0ccd4e27a8e