### PR TITLE
refactor middleware cookies and headers

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,25 +1,27 @@
-﻿import { NextRequest, NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
+import { NextRequest, NextResponse } from "next/server";
+import { createServerClient, CookieOptions } from "@supabase/ssr";
 
 const PROTECTED = ["/dashboard","/contacts","/segments","/marketing","/sequences","/reports","/apps","/settings"];
 
 export async function middleware(req: NextRequest) {
-  let res = NextResponse.next({ request: { headers: req.headers } });
+  let res = NextResponse.next({ request: { headers: new Headers(req.headers) } });
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get: (name: string) => {
-          const cookie = req.cookies.get(name)
-          return cookie ? { name, value: cookie.value } : undefined
+        get(name: string) {
+          const cookie = req.cookies.get(name);
+          return cookie?.value;
         },
-        set: (name: string, value: string, options: any) =>
-          res.cookies.set({ name, value, ...options }),
-        remove: (name: string, options: any) =>
-          res.cookies.set({ name, value: "", ...options, maxAge: 0 }),
-      } as any,
+        set(name: string, value: string, options: CookieOptions) {
+          res.cookies.set({ name, value, ...options });
+        },
+        remove(name: string, options: CookieOptions) {
+          res.cookies.set({ name, value: "", ...options, maxAge: 0 });
+        },
+      },
     }
   );
 


### PR DESCRIPTION
## Summary
- fix middleware to clone request headers
- type Supabase cookie helpers with CookieOptions
- remove BOM from middleware file

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find name 'horizontalListSortingStrategy')*


------
https://chatgpt.com/codex/tasks/task_e_68a5028bb734832daef7c614d9090a55