### PR TITLE
feat: add documents column to contacts table

### DIFF
--- a/src/app/contacts/contacts-data-table.tsx
+++ b/src/app/contacts/contacts-data-table.tsx
@@ -224,6 +224,15 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
         ),
       },
       {
+        accessorKey: "documents",
+        header: "Documents",
+        cell: ({ row }) => {
+          const docs = row.original.documents?.length ?? 0
+          return <span>{docs}</span>
+        },
+        meta: { label: "Documents" },
+      },
+      {
         id: "actions",
         cell: ({ row }) => (
           <RowActions
@@ -314,6 +323,9 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
                 .getAllColumns()
                 .filter((column) => column.getCanHide())
                 .map((column) => {
+                  const label =
+                    (column.columnDef.meta as { label?: string } | undefined)
+                      ?.label ?? column.id
                   return (
                     <DropdownMenuCheckboxItem
                       key={column.id}
@@ -321,7 +333,7 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
                       checked={column.getIsVisible()}
                       onCheckedChange={(value) => column.toggleVisibility(!!value)}
                     >
-                      {column.id}
+                      {label}
                     </DropdownMenuCheckboxItem>
                   )
                 })}


### PR DESCRIPTION
## Summary
- show number of documents in contacts table
- surface column labels in the customize-columns menu

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a502d940ac832dbec183fe91f3dd48