### PR TITLE
Use radio and multi-select inputs for contacts

### DIFF
--- a/src/app/contacts/contacts-data-table.tsx
+++ b/src/app/contacts/contacts-data-table.tsx
@@ -72,6 +72,8 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Label } from "@/components/ui/label"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { MultiSelect } from "@/components/ui/multi-select"
 import {
   Table,
   TableBody,
@@ -662,40 +664,29 @@ function ContactDrawer({ open, onOpenChange, contact, onSave }: ContactDrawerPro
         >
           <div className="space-y-2">
             <Label>Type</Label>
-            <div className="flex flex-wrap gap-2">
+            <RadioGroup
+              className="flex flex-wrap gap-2"
+              value={watch("type")}
+              onValueChange={(v) =>
+                setValue("type", v as Contact["type"])
+              }
+            >
               {contactSchema.shape.type.options.map((opt) => (
-                <Button
-                  key={opt}
-                  type="button"
-                  variant={watch("type") === opt ? "default" : "outline"}
-                  onClick={() => setValue("type", opt)}
-                >
-                  {opt}
-                </Button>
+                <div key={opt} className="flex items-center space-x-2">
+                  <RadioGroupItem value={opt} id={`type-${opt}`} />
+                  <Label htmlFor={`type-${opt}`}>{opt}</Label>
+                </div>
               ))}
-            </div>
+            </RadioGroup>
           </div>
           <div className="space-y-2">
             <Label>Roles</Label>
-            {roles.map((role) => (
-              <div key={role} className="flex items-center space-x-2">
-                <Checkbox
-                  checked={watch("roles")?.includes(role)}
-                  onCheckedChange={(checked) => {
-                    const currentRoles = watch("roles") ?? []
-                    if (checked) {
-                      setValue("roles", [...currentRoles, role])
-                    } else {
-                      setValue(
-                        "roles",
-                        currentRoles.filter((r) => r !== role)
-                      )
-                    }
-                  }}
-                />
-                <span>{role}</span>
-              </div>
-            ))}
+            <MultiSelect
+              options={roles.map((r) => ({ label: r, value: r }))}
+              value={watch("roles") ?? []}
+              onChange={(vals) => setValue("roles", vals)}
+              placeholder="Select roles"
+            />
           </div>
           <div className="grid gap-2">
             <Input placeholder="Honorific" {...register("honorific")} />

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -44,3 +44,4 @@ export * from './textarea';
 export * from './toggle-group';
 export * from './toggle';
 export * from './tooltip';
+export * from './multi-select';

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { Check, ChevronsUpDown } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+import { Button } from "@/components/ui/button"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command"
+
+export interface MultiSelectOption {
+  label: string
+  value: string
+}
+
+interface MultiSelectProps {
+  options: MultiSelectOption[]
+  value: string[]
+  onChange: (value: string[]) => void
+  placeholder?: string
+}
+
+export function MultiSelect({
+  options,
+  value,
+  onChange,
+  placeholder = "Select",
+}: MultiSelectProps) {
+  const [open, setOpen] = React.useState(false)
+
+  const toggleValue = React.useCallback(
+    (val: string) => {
+      if (value.includes(val)) {
+        onChange(value.filter((v) => v !== val))
+      } else {
+        onChange([...value, val])
+      }
+    },
+    [value, onChange]
+  )
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          className="w-full justify-between"
+        >
+          {value.length > 0 ? value.join(", ") : placeholder}
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-full p-0">
+        <Command>
+          <CommandGroup>
+            {options.map((option) => {
+              const selected = value.includes(option.value)
+              return (
+                <CommandItem
+                  key={option.value}
+                  onSelect={() => toggleValue(option.value)}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      selected ? "opacity-100" : "opacity-0"
+                    )}
+                  />
+                  {option.label}
+                </CommandItem>
+              )
+            })}
+          </CommandGroup>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+


### PR DESCRIPTION
## Summary
- replace contact type buttons with radio group for single selection
- switch roles checkboxes to reusable multi-select component
- expose new multi-select UI primitive

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: Cannot find name 'horizontalListSortingStrategy')*

------
https://chatgpt.com/codex/tasks/task_e_68a502da8820832d8de51a35c80d9aef