### PR TITLE
fix: add missing horizontal sorting strategy

### DIFF
--- a/src/app/contacts/contacts-data-table.tsx
+++ b/src/app/contacts/contacts-data-table.tsx
@@ -18,6 +18,7 @@ import { DndContext, DragEndEvent } from "@dnd-kit/core"
 import {
   SortableContext,
   verticalListSortingStrategy,
+  horizontalListSortingStrategy,
   arrayMove,
   useSortable,
 } from "@dnd-kit/sortable"


### PR DESCRIPTION
## Summary
- import `horizontalListSortingStrategy` for contact table column sorting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a506f806e0832db200046d614558cc