### PR TITLE
Organize contact form into tabs

### DIFF
--- a/src/app/contacts/components/contact-drawer.tsx
+++ b/src/app/contacts/components/contact-drawer.tsx
@@ -29,6 +29,7 @@ import {
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { MultiSelect } from "@/components/ui/multi-select"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
 
 interface ContactDrawerProps {
   open: boolean
@@ -99,161 +100,184 @@ export function ContactDrawer({ open, onOpenChange, contact, onSave }: ContactDr
           <DrawerTitle>{contact ? "Edit Contact" : "New Contact"}</DrawerTitle>
           <DrawerDescription>Manage contact details</DrawerDescription>
         </DrawerHeader>
-        <form
-          id="contact-form"
-          onSubmit={onSubmit}
-          className="overflow-y-auto px-4 pb-4 space-y-4"
-        >
-          <div className="space-y-2">
-            <Label>Type</Label>
-            <RadioGroup
-              className="flex flex-wrap gap-2"
-              value={watch("type")}
-              onValueChange={(v) => setValue("type", v as Contact["type"])}
+        <form id="contact-form" onSubmit={onSubmit} className="h-full">
+          <Tabs defaultValue="details" className="flex h-full flex-col">
+            <TabsList className="px-4">
+              <TabsTrigger value="details">Details</TabsTrigger>
+              <TabsTrigger value="communication">Communication</TabsTrigger>
+              <TabsTrigger value="preferences">Preferences</TabsTrigger>
+            </TabsList>
+            <TabsContent
+              value="details"
+              className="space-y-4 overflow-y-auto px-4 pb-4"
             >
-              {contactSchema.shape.type.options.map((opt) => (
-                <div key={opt} className="flex items-center space-x-2">
-                  <RadioGroupItem value={opt} id={`type-${opt}`} />
-                  <Label htmlFor={`type-${opt}`}>{opt}</Label>
-                </div>
-              ))}
-            </RadioGroup>
-          </div>
-          <div className="space-y-2">
-            <Label>Roles</Label>
-            <MultiSelect
-              options={roles.map((r) => ({ label: r, value: r }))}
-              value={watch("roles") ?? []}
-              onChange={(vals) => setValue("roles", vals)}
-              placeholder="Select roles"
-            />
-          </div>
-          <div className="grid gap-2">
-            <Input placeholder="Honorific" {...register("honorific")} />
-            <Input placeholder="First Name" {...register("firstName")} />
-            <Input placeholder="Middle Name" {...register("middleName")} />
-            <Input placeholder="Last Name" {...register("lastName")} />
-            <Input placeholder="Aliases" {...register("aliases")} />
-            <Input
-              placeholder="How to Credit Publicly"
-              {...register("howToCreditPublicly")}
-            />
-            <Select
-              value={watch("pronouns")}
-              onValueChange={(v) => setValue("pronouns", v as Contact["pronouns"])}
+              <div className="space-y-2">
+                <Label>Type</Label>
+                <RadioGroup
+                  className="flex flex-wrap gap-2"
+                  value={watch("type")}
+                  onValueChange={(v) => setValue("type", v as Contact["type"])}
+                >
+                  {contactSchema.shape.type.options.map((opt) => (
+                    <div key={opt} className="flex items-center space-x-2">
+                      <RadioGroupItem value={opt} id={`type-${opt}`} />
+                      <Label htmlFor={`type-${opt}`}>{opt}</Label>
+                    </div>
+                  ))}
+                </RadioGroup>
+              </div>
+              <div className="space-y-2">
+                <Label>Roles</Label>
+                <MultiSelect
+                  options={roles.map((r) => ({ label: r, value: r }))}
+                  value={watch("roles") ?? []}
+                  onChange={(vals) => setValue("roles", vals)}
+                  placeholder="Select roles"
+                />
+              </div>
+              <div className="grid gap-2">
+                <Input placeholder="Honorific" {...register("honorific")} />
+                <Input placeholder="First Name" {...register("firstName")} />
+                <Input placeholder="Middle Name" {...register("middleName")} />
+                <Input placeholder="Last Name" {...register("lastName")} />
+                <Input placeholder="Aliases" {...register("aliases")} />
+                <Input
+                  placeholder="How to Credit Publicly"
+                  {...register("howToCreditPublicly")}
+                />
+                <Select
+                  value={watch("pronouns")}
+                  onValueChange={(v) =>
+                    setValue("pronouns", v as Contact["pronouns"])
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pronouns" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {pronounOptions.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        {p}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Input placeholder="Job Title" {...register("jobTitle")} />
+                <Input
+                  placeholder="Company / Organization Name"
+                  {...register("company")}
+                />
+              </div>
+              <div className="grid gap-2">
+                <Input
+                  type="date"
+                  placeholder="Date of Birth"
+                  {...register("dateOfBirth")}
+                />
+                <Input type="file" {...register("documents")} multiple />
+              </div>
+            </TabsContent>
+            <TabsContent
+              value="communication"
+              className="space-y-4 overflow-y-auto px-4 pb-4"
             >
-              <SelectTrigger>
-                <SelectValue placeholder="Pronouns" />
-              </SelectTrigger>
-              <SelectContent>
-                {pronounOptions.map((p) => (
-                  <SelectItem key={p} value={p}>
-                    {p}
-                  </SelectItem>
+              <div className="grid gap-2">
+                <Input
+                  placeholder="Primary Email"
+                  {...register("primaryEmail")}
+                />
+                {altEmailFields.map((field, index) => (
+                  <div key={field.id} className="flex space-x-2">
+                    <Input
+                      className="flex-1"
+                      placeholder="Alternate Email"
+                      {...register(`alternateEmails.${index}` as const)}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={() => removeEmail(index)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
                 ))}
-              </SelectContent>
-            </Select>
-            <Input placeholder="Job Title" {...register("jobTitle")} />
-            <Input
-              placeholder="Company / Organization Name"
-              {...register("company")}
-            />
-          </div>
-          <div className="grid gap-2">
-            <Input placeholder="Primary Email" {...register("primaryEmail")} />
-            {altEmailFields.map((field, index) => (
-              <div key={field.id} className="flex space-x-2">
+                {altEmailFields.length < 2 && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => appendEmail("")}
+                  >
+                    Add another email
+                  </Button>
+                )}
+                <Input placeholder="Website" {...register("website")} />
                 <Input
-                  className="flex-1"
-                  placeholder="Alternate Email"
-                  {...register(`alternateEmails.${index}` as const)}
+                  placeholder="Social Media"
+                  {...register("socialMedia")}
                 />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => removeEmail(index)}
-                >
-                  Remove
-                </Button>
               </div>
-            ))}
-            {altEmailFields.length < 2 && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => appendEmail("")}
-              >
-                Add another email
-              </Button>
-            )}
-            <Input placeholder="Website" {...register("website")} />
-            <Input
-              placeholder="Social Media"
-              {...register("socialMedia")}
-            />
-          </div>
-          <div className="grid gap-2">
-            {phoneFields.map((field, index) => (
-              <div key={field.id} className="flex space-x-2">
-                <Input
-                  className="flex-1"
-                  placeholder="Phone Number"
-                  {...register(`phoneNumbers.${index}` as const)}
-                />
-                <Button
-                  type="button"
-                  variant="ghost"
-                  onClick={() => removePhone(index)}
-                >
-                  Remove
-                </Button>
+              <div className="grid gap-2">
+                {phoneFields.map((field, index) => (
+                  <div key={field.id} className="flex space-x-2">
+                    <Input
+                      className="flex-1"
+                      placeholder="Phone Number"
+                      {...register(`phoneNumbers.${index}` as const)}
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={() => removePhone(index)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                ))}
+                {phoneFields.length < 3 && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => appendPhone("")}
+                  >
+                    Add phone number
+                  </Button>
+                )}
               </div>
-            ))}
-            {phoneFields.length < 3 && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                onClick={() => appendPhone("")}
-              >
-                Add phone number
-              </Button>
-            )}
-          </div>
-          <div className="grid gap-2">
-            <Input
-              type="date"
-              placeholder="Date of Birth"
-              {...register("dateOfBirth")}
-            />
-            <Input type="file" {...register("documents")} multiple />
-          </div>
-          <div className="space-y-2">
-            <Label>Mailing Lists</Label>
-            {mailingListOptions.map((list) => (
-              <div key={list} className="flex items-center space-x-2">
-                <Checkbox
-                  checked={watch("mailingLists")?.includes(list)}
-                  onCheckedChange={(checked) => {
-                    const lists = watch("mailingLists") ?? []
-                    if (checked) {
-                      setValue("mailingLists", [...lists, list])
-                    } else {
-                      setValue(
-                        "mailingLists",
-                        lists.filter((l) => l !== list)
-                      )
-                    }
-                  }}
-                />
-                <span>{list}</span>
+            </TabsContent>
+            <TabsContent
+              value="preferences"
+              className="space-y-4 overflow-y-auto px-4 pb-4"
+            >
+              <div className="space-y-2">
+                <Label>Mailing Lists</Label>
+                {mailingListOptions.map((list) => (
+                  <div key={list} className="flex items-center space-x-2">
+                    <Checkbox
+                      checked={watch("mailingLists")?.includes(list)}
+                      onCheckedChange={(checked) => {
+                        const lists = watch("mailingLists") ?? []
+                        if (checked) {
+                          setValue("mailingLists", [...lists, list])
+                        } else {
+                          setValue(
+                            "mailingLists",
+                            lists.filter((l) => l !== list)
+                          )
+                        }
+                      }}
+                    />
+                    <span>{list}</span>
+                  </div>
+                ))}
+                <div className="flex items-center space-x-2">
+                  <Checkbox {...register("doNotEmail")} /> <span>Do not email</span>
+                </div>
               </div>
-            ))}
-            <div className="flex items-center space-x-2">
-              <Checkbox {...register("doNotEmail")} /> <span>Do not email</span>
-            </div>
-          </div>
+            </TabsContent>
+          </Tabs>
         </form>
         <DrawerFooter className="border-t p-4">
           <Button type="submit" form="contact-form">


### PR DESCRIPTION
## Summary
- wrap contact drawer fields in a tabbed interface using Details, Communication, and Preferences sections
- ensure each tab scrolls independently while submitting as a single form

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5447e2408832db477f746c4bbc57a