### PR TITLE
fix: import missing icon components

### DIFF
--- a/src/app/contacts/components/contact-drawer.tsx
+++ b/src/app/contacts/components/contact-drawer.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { useForm, useFieldArray, type Resolver } from "react-hook-form"
 import { zodResolver } from "@hookform/resolvers/zod"
+import { Mail, Phone } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { contactSchema, type Contact } from "../data"


### PR DESCRIPTION
## Summary
- import mail and phone icons for contact drawer actions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a54d04bac0832db2de743020d56410