### PR TITLE
fix contacts table header clipping

### DIFF
--- a/src/app/contacts/contacts-data-table.tsx
+++ b/src/app/contacts/contacts-data-table.tsx
@@ -360,7 +360,7 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
           </Popover>
         </div>
       </div>
-      <div className="rounded-md border">
+      <div className="rounded-md border overflow-hidden">
         <DndContext onDragEnd={handleDragEnd}>
           <SortableContext
             items={table.getRowModel().rows.map((row) => row.id)}


### PR DESCRIPTION
## Summary
- ensure contact table header stays within rounded container by adding overflow hidden

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60fc51990832da6b254194896c820