### PR TITLE
feat: add signup page and form

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { SignupForm } from "@/components/signup-form";
+
+export default function SignupPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md">
+        <SignupForm />
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout-wrapper.tsx
+++ b/src/components/layout-wrapper.tsx
@@ -7,7 +7,8 @@ import { AppSidebar } from '@/components/app-sidebar'
 
 export function LayoutWrapper({ children }: { children: ReactNode }) {
   const pathname = usePathname()
-  const showSidebar = pathname !== '/' && pathname !== '/login'
+  const showSidebar =
+    pathname !== '/' && pathname !== '/login' && pathname !== '/signup'
 
   if (!showSidebar) {
     return <>{children}</>

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -58,7 +58,7 @@ export function LoginForm({
             </div>
             <div className="mt-4 text-center text-sm">
               Don&apos;t have an account?{" "}
-              <a href="#" className="underline underline-offset-4">
+              <a href="/signup" className="underline underline-offset-4">
                 Sign up
               </a>
             </div>

--- a/src/components/signup-form.tsx
+++ b/src/components/signup-form.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { cn } from "@/lib/utils";
+import { createSupabaseBrowser } from "@/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+export function SignupForm({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  const router = useRouter();
+  const supabase = createSupabaseBrowser();
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const email = formData.get("email") as string;
+    const password = formData.get("password") as string;
+    const confirm = formData.get("confirm") as string;
+
+    if (password !== confirm) {
+      setError("Passwords do not match");
+      return;
+    }
+
+    setError(null);
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: `${location.origin}/login` },
+    });
+
+    if (error) {
+      setError(error.message);
+    } else {
+      setSuccess(true);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className={cn("flex flex-col gap-6", className)} {...props}>
+        <Card>
+          <CardHeader>
+            <CardTitle>Check your email</CardTitle>
+            <CardDescription>
+              We sent you a confirmation link.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Button className="w-full" onClick={() => router.push("/login")}>
+              Back to login
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col gap-6", className)} {...props}>
+      <Card>
+        <CardHeader>
+          <CardTitle>Create an account</CardTitle>
+          <CardDescription>
+            Enter your email below to create your account
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit}>
+            <div className="flex flex-col gap-6">
+              <div className="grid gap-3">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  name="email"
+                  type="email"
+                  placeholder="m@example.com"
+                  required
+                />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="password">Password</Label>
+                <Input id="password" name="password" type="password" required />
+              </div>
+              <div className="grid gap-3">
+                <Label htmlFor="confirm">Confirm password</Label>
+                <Input id="confirm" name="confirm" type="password" required />
+              </div>
+              {error && <p className="text-sm text-red-500">{error}</p>}
+              <div className="flex flex-col gap-3">
+                <Button type="submit" className="w-full">
+                  Create account
+                </Button>
+                <Button variant="outline" className="w-full">
+                  Sign up with Google
+                </Button>
+              </div>
+            </div>
+            <div className="mt-4 text-center text-sm">
+              Already have an account?{" "}
+              <a href="/login" className="underline underline-offset-4">
+                Log in
+              </a>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add signup form with email confirmation flow
- add dedicated signup page and link from login
- hide dashboard sidebar on signup page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60f4d83b0832d932c99ec62874c0c