### PR TITLE
Fix contacts page popovers and hydration mismatch

### DIFF
--- a/src/app/contacts/components/draggable-column-header.tsx
+++ b/src/app/contacts/components/draggable-column-header.tsx
@@ -25,6 +25,9 @@ export function DraggableColumnHeader({ header }: DraggableColumnHeaderProps) {
   const SortIcon =
     sorted === "asc" ? ArrowUp : sorted === "desc" ? ArrowDown : ChevronsUpDown
 
+  const [mounted, setMounted] = React.useState(false)
+  React.useEffect(() => setMounted(true), [])
+
   return (
     <TableHead
       ref={setNodeRef}
@@ -35,8 +38,8 @@ export function DraggableColumnHeader({ header }: DraggableColumnHeaderProps) {
           ? header.column.getToggleSortingHandler()
           : undefined
       }
-      {...attributes}
-      {...listeners}
+      {...(mounted ? attributes : {})}
+      {...(mounted ? listeners : {})}
     >
       <div className="flex items-center">
         {header.isPlaceholder

--- a/src/app/contacts/contacts-data-table.tsx
+++ b/src/app/contacts/contacts-data-table.tsx
@@ -386,6 +386,7 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
                       className="capitalize"
                       checked={column.getIsVisible()}
                       onCheckedChange={(value) => column.toggleVisibility(!!value)}
+                      onSelect={(e) => e.preventDefault()}
                     >
                       {label}
                     </DropdownMenuCheckboxItem>
@@ -399,7 +400,7 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
                 <Plus className="mr-2 h-4 w-4" /> Add
               </Button>
             </PopoverTrigger>
-            <PopoverContent align="end" className="w-48">
+            <PopoverContent align="end" className="w-56 p-2">
               <div className="flex flex-col">
                 <Button variant="ghost" className="justify-start" onClick={handleAddNew}>
                   <UserPlus className="mr-2 h-4 w-4" /> Add New Contact
@@ -420,7 +421,7 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
                 </Button>
                 <Button
                   variant="ghost"
-                  className="justify-start"
+                  className="justify-start whitespace-normal text-left"
                   onClick={() => toast("Download template not implemented")}
                 >
                   <FileDown className="mr-2 h-4 w-4" /> Download Template .csv


### PR DESCRIPTION
## Summary
- prevent customize-columns menu from closing after each selection
- allow Add menu items to wrap and reduce popover padding to avoid overflow
- avoid hydration mismatch in draggable column headers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a61a619260832d94eca0b584083dbe