### PR TITLE
refactor: redesign contact drawer

### DIFF
--- a/src/app/contacts/contacts-data-table.tsx
+++ b/src/app/contacts/contacts-data-table.tsx
@@ -613,6 +613,10 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
           saveContact(c)
           setDrawerOpen(false)
         }}
+        onDelete={(id) => {
+          deleteContact(id)
+          setDrawerOpen(false)
+        }}
       />
     </div>
   )

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -1,0 +1,56 @@
+"use client"
+
+import * as React from "react"
+import { UploadCloud } from "lucide-react"
+
+interface DropzoneProps {
+  files?: File[]
+  onFiles?: (files: File[]) => void
+}
+
+export function Dropzone({ files = [], onFiles }: DropzoneProps) {
+  const [localFiles, setLocalFiles] = React.useState<File[]>(files)
+  const inputRef = React.useRef<HTMLInputElement>(null)
+
+  React.useEffect(() => {
+    setLocalFiles(files)
+  }, [files])
+
+  const handleFiles = (fileList: FileList | null) => {
+    if (!fileList) return
+    const newFiles = Array.from(fileList)
+    const updated = [...localFiles, ...newFiles]
+    setLocalFiles(updated)
+    onFiles?.(updated)
+  }
+
+  return (
+    <div
+      className="flex flex-col items-center justify-center rounded-md border-2 border-dashed p-8 text-center text-sm cursor-pointer"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => {
+        e.preventDefault()
+        handleFiles(e.dataTransfer.files)
+      }}
+      onClick={() => inputRef.current?.click()}
+    >
+      <UploadCloud className="mb-2 h-6 w-6 text-muted-foreground" />
+      <p className="text-muted-foreground">Drag files here or click to upload</p>
+      <input
+        ref={inputRef}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={(e) => handleFiles(e.target.files)}
+      />
+      {localFiles.length > 0 && (
+        <ul className="mt-4 w-full text-left text-xs">
+          {localFiles.map((file) => (
+            <li key={file.name}>{file.name}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -45,3 +45,4 @@ export * from './toggle-group';
 export * from './toggle';
 export * from './tooltip';
 export * from './multi-select';
+export * from './dropzone';


### PR DESCRIPTION
## Summary
- restyle contact drawer tabs with underline variant and add Documents tab with dropzone
- align Type and Roles fields side-by-side with labeled inputs and separators
- replace email/phone actions with delete confirmation

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*
- `npx shadcn@latest add https://supabase.com/ui/r/dropzone-nextjs.json` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a62381cc4c832d8e418e508d134f52