### PR TITLE
Enable sorting and add contacts empty state

### DIFF
--- a/src/app/contacts/components/draggable-column-header.tsx
+++ b/src/app/contacts/components/draggable-column-header.tsx
@@ -4,7 +4,12 @@ import * as React from "react"
 import { Header, flexRender } from "@tanstack/react-table"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react"
+import {
+  ArrowDown,
+  ArrowUp,
+  ChevronsUpDown,
+  GripVertical,
+} from "lucide-react"
 
 import { TableHead } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
@@ -32,20 +37,31 @@ export function DraggableColumnHeader({ header }: DraggableColumnHeaderProps) {
     <TableHead
       ref={setNodeRef}
       style={style}
-      className={cn("cursor-pointer select-none", isDragging && "opacity-50")}
-      onClick={
-        header.column.getCanSort()
-          ? header.column.getToggleSortingHandler()
-          : undefined
-      }
-      {...(mounted ? attributes : {})}
-      {...(mounted ? listeners : {})}
+      className={cn(isDragging && "opacity-50")}
     >
       <div className="flex items-center">
-        {header.isPlaceholder
-          ? null
-          : flexRender(header.column.columnDef.header, header.getContext())}
-        {header.column.getCanSort() && <SortIcon className="ml-2 h-4 w-4" />}
+        <span
+          className="mr-2 cursor-grab"
+          {...(mounted ? attributes : {})}
+          {...(mounted ? listeners : {})}
+        >
+          <GripVertical className="h-4 w-4" />
+        </span>
+        <div
+          className="flex cursor-pointer select-none items-center"
+          onClick={
+            header.column.getCanSort()
+              ? header.column.getToggleSortingHandler()
+              : undefined
+          }
+        >
+          {header.isPlaceholder
+            ? null
+            : flexRender(header.column.columnDef.header, header.getContext())}
+          {header.column.getCanSort() && (
+            <SortIcon className="ml-2 h-4 w-4" />
+          )}
+        </div>
       </div>
     </TableHead>
   )

--- a/src/app/contacts/contacts-data-table.tsx
+++ b/src/app/contacts/contacts-data-table.tsx
@@ -32,6 +32,7 @@ import {
   FileDown,
   Trash,
   Archive as ArchiveIcon,
+  Box,
 } from "lucide-react"
 import { toast } from "sonner"
 
@@ -531,6 +532,29 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
                     ))}
                   </TableRow>
                 ))
+              ) : contacts.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={columns.length}>
+                    <div className="flex h-80 flex-col items-center justify-center text-center">
+                      <Box className="mb-4 h-12 w-12 text-muted-foreground" />
+                      <h3 className="mb-1 text-lg font-semibold">No person records</h3>
+                      <p className="mb-6 text-sm text-muted-foreground">
+                        People records let you track individuals and contacts at a firm.
+                      </p>
+                      <div className="flex gap-2">
+                        <Button onClick={handleAddNew}>
+                          <UserPlus className="mr-2 h-4 w-4" /> Add a contact
+                        </Button>
+                        <Button
+                          variant="outline"
+                          onClick={() => toast("Upload not implemented")}
+                        >
+                          <Upload className="mr-2 h-4 w-4" /> Upload .csv
+                        </Button>
+                      </div>
+                    </div>
+                  </TableCell>
+                </TableRow>
               ) : (
                 <TableRow>
                   <TableCell colSpan={columns.length} className="h-24 text-center">


### PR DESCRIPTION
## Summary
- make column headers sortable with a separate drag handle
- show a friendly empty state with actions to add or upload contacts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit --diagnostics`


------
https://chatgpt.com/codex/tasks/task_e_68a63660409c832d9afd7e8dd25f130c