### PR TITLE
feat: improve file cards and track donations

### DIFF
--- a/src/app/contacts/components/contact-drawer.tsx
+++ b/src/app/contacts/components/contact-drawer.tsx
@@ -90,6 +90,7 @@ export function ContactDrawer({ open, onOpenChange, contact, onSave, onDelete }:
       phoneNumbers: [""],
       mailingLists: [],
       attribution: "",
+      donations: [],
       doNotEmail: false,
     },
   })

--- a/src/app/contacts/contacts-data-table.tsx
+++ b/src/app/contacts/contacts-data-table.tsx
@@ -111,6 +111,7 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
     phoneNumbers: [""],
     mailingLists: [],
     attribution: "",
+    donations: [],
     doNotEmail: false,
   }), [])
 
@@ -230,6 +231,18 @@ export function ContactsDataTable({ data }: ContactsDataTableProps) {
         accessorKey: "company",
         header: "Company / Organization Name",
         meta: { label: "Company / Organization Name" },
+      },
+      {
+        id: "totalDonations",
+        accessorFn: (row) =>
+          row.donations?.reduce((sum, d) => sum + d.amount, 0) ?? 0,
+        header: "Total Donations",
+        cell: ({ row }) => {
+          const total =
+            row.original.donations?.reduce((sum, d) => sum + d.amount, 0) ?? 0
+          return `$${total.toFixed(2)}`
+        },
+        meta: { label: "Total Donations" },
       },
       {
         accessorKey: "primaryEmail",

--- a/src/app/contacts/data.ts
+++ b/src/app/contacts/data.ts
@@ -43,6 +43,15 @@ export const contactSchema = z.object({
   // Documents & Lists
   documents: z.array(z.any()).optional(),
   mailingLists: z.array(z.string()).optional(),
+  // Donations
+  donations: z
+    .array(
+      z.object({
+        amount: z.number(),
+        date: z.string().optional(),
+      })
+    )
+    .optional(),
   doNotEmail: z.boolean().default(false),
 })
 
@@ -60,6 +69,10 @@ export const contacts: Contact[] = [
     primaryEmail: "alice@example.com",
     phoneNumbers: ["123-456-7890"],
     mailingLists: ["Newsletter"],
+    donations: [
+      { amount: 500, date: "2024-03-15" },
+      { amount: 250, date: "2024-06-01" },
+    ],
     doNotEmail: false,
   },
   {
@@ -70,6 +83,7 @@ export const contacts: Contact[] = [
     company: "Beta Corp",
     primaryEmail: "contact@betacorp.com",
     mailingLists: ["Newsletter", "Events"],
+    donations: [{ amount: 1000, date: "2024-02-10" }],
     doNotEmail: false,
   },
   {
@@ -81,6 +95,7 @@ export const contacts: Contact[] = [
     company: "Creative Solutions",
     primaryEmail: "carol@example.com",
     phoneNumbers: ["555-555-5555"],
+    donations: [],
     doNotEmail: true,
   },
 ]

--- a/src/components/ui/dropzone.tsx
+++ b/src/components/ui/dropzone.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { UploadCloud, X } from "lucide-react"
+import { UploadCloud, Trash, File as FileIcon } from "lucide-react"
 import {
   Card,
   CardContent,
@@ -38,59 +38,76 @@ export function Dropzone({ files = [], onFiles }: DropzoneProps) {
   }
 
   return (
-    <div
-      className="flex min-h-[200px] flex-col items-center justify-center rounded-md border-2 border-dashed p-10 text-center text-sm cursor-pointer"
-      onDragOver={(e) => e.preventDefault()}
-      onDrop={(e) => {
-        e.preventDefault()
-        handleFiles(e.dataTransfer.files)
-      }}
-      onClick={() => inputRef.current?.click()}
-    >
-      <UploadCloud className="mb-2 h-6 w-6 text-muted-foreground" />
-      <p className="text-muted-foreground">Drag files here or click to upload</p>
-      <input
-        ref={inputRef}
-        type="file"
-        multiple
-        accept=".pdf,.csv,application/pdf,text/csv"
-        className="hidden"
-        onChange={(e) => handleFiles(e.target.files)}
-      />
+    <div>
+      <div
+        className="flex min-h-[200px] flex-col items-center justify-center rounded-md border-2 border-dashed p-10 text-center text-sm cursor-pointer"
+        onDragOver={(e) => e.preventDefault()}
+        onDrop={(e) => {
+          e.preventDefault()
+          handleFiles(e.dataTransfer.files)
+        }}
+        onClick={() => inputRef.current?.click()}
+      >
+        <UploadCloud className="mb-2 h-6 w-6 text-muted-foreground" />
+        <p className="text-muted-foreground">Drag files here or click to upload</p>
+        <input
+          ref={inputRef}
+          type="file"
+          multiple
+          accept=".pdf,.csv,application/pdf,text/csv"
+          className="hidden"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+      </div>
       {files.length > 0 && (
-        <ul className="mt-4 grid w-full grid-cols-1 gap-4 sm:grid-cols-2">
-          {files.map((file, index) => (
-            <li key={file.name} onClick={(e) => e.stopPropagation()}>
-              <Card className="overflow-hidden">
-                <CardContent className="p-0">
-                  <img
-                    src={URL.createObjectURL(file)}
-                    alt={file.name}
-                    className="h-40 w-full object-cover"
-                  />
-                </CardContent>
-                <CardFooter className="justify-between">
-                  <div className="flex flex-col items-start">
-                    <CardTitle className="text-sm">{file.name}</CardTitle>
-                    <CardDescription>{Math.round(file.size / 1024)} KB</CardDescription>
+        <div className="mt-4">
+          <h4 className="mb-2 text-sm font-medium">Files</h4>
+          <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {files.map((file, index) => (
+              <li key={file.name} onClick={(e) => e.stopPropagation()}>
+                <Card className="relative aspect-square overflow-hidden">
+                  <div className="absolute right-1 top-1 z-10">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        removeFile(index)
+                      }}
+                    >
+                      <Trash className="h-4 w-4" />
+                      <span className="sr-only">Remove</span>
+                    </Button>
                   </div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      removeFile(index)
-                    }}
-                  >
-                    <X className="h-4 w-4" />
-                    <span className="sr-only">Remove</span>
-                  </Button>
-                </CardFooter>
-              </Card>
-            </li>
-          ))}
-        </ul>
+                  <CardContent className="p-0">
+                    {file.type.startsWith("image/") ? (
+                      <img
+                        src={URL.createObjectURL(file)}
+                        alt={file.name}
+                        className="h-full w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-muted">
+                        <FileIcon className="h-8 w-8 text-muted-foreground" />
+                      </div>
+                    )}
+                  </CardContent>
+                  <CardFooter className="absolute bottom-0 left-0 right-0 flex flex-col items-start bg-gradient-to-t from-background/90 p-2">
+                    <CardTitle
+                      className="w-full truncate text-sm"
+                      title={file.name}
+                    >
+                      {file.name}
+                    </CardTitle>
+                    <CardDescription>{Math.round(file.size / 1024)} KB</CardDescription>
+                  </CardFooter>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- keep uploaded file cards outside dropzone with better layout and trash delete
- add donations field for contacts and show total donations column in table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a63c8c250c832d8e84893ed2a32550