### PR TITLE
feat: add marketing api handlers

### DIFF
--- a/src/app/api/autosave/route.ts
+++ b/src/app/api/autosave/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getSessionOrg } from "@/lib/auth";
+import { db } from "@/lib/store";
+
+const saveSchema = z.object({
+  key: z.string(),
+  data: z.any(),
+});
+
+export async function GET(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { searchParams } = new URL(req.url);
+  const key = searchParams.get("key");
+  if (!key) {
+    return NextResponse.json({ error: "Missing key" }, { status: 422 });
+  }
+  const orgStore = db.autosave.get(orgId);
+  const entry = orgStore?.get(key);
+  if (!entry) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  return NextResponse.json(entry);
+}
+
+export async function POST(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = saveSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  let orgStore = db.autosave.get(orgId);
+  if (!orgStore) {
+    orgStore = new Map();
+    db.autosave.set(orgId, orgStore);
+  }
+  const entry = {
+    key: parsed.data.key,
+    data: parsed.data.data,
+    updatedAt: new Date().toISOString(),
+  };
+  orgStore.set(parsed.data.key, entry);
+  return NextResponse.json(entry);
+}

--- a/src/app/api/campaigns/[id]/route.ts
+++ b/src/app/api/campaigns/[id]/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getSessionOrg } from "@/lib/auth";
+import { db } from "@/lib/store";
+
+const updateSchema = z.object({
+  name: z.string().optional(),
+  contentJson: z.any().optional(),
+  segmentId: z.string().optional(),
+  sendAt: z.string().optional(),
+  status: z.enum(["DRAFT", "SCHEDULED", "SENT"]).optional(),
+});
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const campaign = db.campaigns.get(params.id);
+  if (!campaign) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (campaign.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return NextResponse.json({ campaign });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const campaign = db.campaigns.get(params.id);
+  if (!campaign) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (campaign.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  const { segmentId } = parsed.data;
+  if (segmentId) {
+    const seg = db.segments.get(segmentId);
+    if (!seg) {
+      return NextResponse.json({ error: "Segment not found" }, { status: 422 });
+    }
+    if (seg.orgId !== orgId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+  Object.assign(campaign, parsed.data, { updatedAt: new Date().toISOString() });
+  db.campaigns.set(campaign.id, campaign);
+  return NextResponse.json({ campaign });
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const campaign = db.campaigns.get(params.id);
+  if (!campaign) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (campaign.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  db.campaigns.delete(campaign.id);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/campaigns/[id]/send/route.ts
+++ b/src/app/api/campaigns/[id]/send/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getSessionOrg } from "@/lib/auth";
+import { db } from "@/lib/store";
+
+const sendSchema = z.object({
+  sendAt: z.string().optional(),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const campaign = db.campaigns.get(params.id);
+  if (!campaign) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (campaign.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = sendSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  const sendAt = parsed.data.sendAt || new Date().toISOString();
+  campaign.sendAt = sendAt;
+  campaign.status =
+    new Date(sendAt) > new Date() ? "SCHEDULED" : "SENT";
+  campaign.updatedAt = new Date().toISOString();
+  db.campaigns.set(campaign.id, campaign);
+  return NextResponse.json({ campaign });
+}

--- a/src/app/api/campaigns/route.ts
+++ b/src/app/api/campaigns/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { getSessionOrg } from "@/lib/auth";
+import { db, Campaign, CampaignStatus } from "@/lib/store";
+
+const PAGE_SIZE = 10;
+
+const createSchema = z.object({
+  name: z.string(),
+  contentJson: z.any(),
+  segmentId: z.string().optional(),
+  sendAt: z.string().optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { searchParams } = new URL(req.url);
+  const cursor = searchParams.get("cursor") || undefined;
+  const campaigns = Array.from(db.campaigns.values()).filter(
+    (c) => c.orgId === orgId
+  );
+  campaigns.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  const start = cursor ? campaigns.findIndex((c) => c.id === cursor) + 1 : 0;
+  const page = campaigns.slice(start, start + PAGE_SIZE);
+  const nextCursor =
+    start + PAGE_SIZE < campaigns.length ? page[page.length - 1].id : null;
+  return NextResponse.json({ campaigns: page, nextCursor });
+}
+
+export async function POST(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  const { name, contentJson, segmentId, sendAt } = parsed.data;
+  if (segmentId) {
+    const seg = db.segments.get(segmentId);
+    if (!seg) {
+      return NextResponse.json({ error: "Segment not found" }, { status: 422 });
+    }
+    if (seg.orgId !== orgId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+  const now = new Date().toISOString();
+  const status: CampaignStatus = sendAt ? "SCHEDULED" : "DRAFT";
+  const campaign: Campaign = {
+    id: randomUUID(),
+    orgId,
+    name,
+    contentJson,
+    status,
+    sendAt,
+    segmentId,
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.campaigns.set(campaign.id, campaign);
+  return NextResponse.json({ campaign });
+}

--- a/src/app/api/segments/[id]/members/route.ts
+++ b/src/app/api/segments/[id]/members/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getSessionOrg } from "@/lib/auth";
+import { db } from "@/lib/store";
+
+const membersSchema = z.object({
+  contactIds: z.array(z.string()),
+});
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const segment = db.segments.get(params.id);
+  if (!segment) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (segment.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = membersSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  for (const id of parsed.data.contactIds) {
+    if (!segment.members.includes(id)) segment.members.push(id);
+  }
+  segment.updatedAt = new Date().toISOString();
+  return NextResponse.json({ members: segment.members });
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const segment = db.segments.get(params.id);
+  if (!segment) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (segment.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = membersSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  segment.members = segment.members.filter(
+    (m) => !parsed.data.contactIds.includes(m)
+  );
+  segment.updatedAt = new Date().toISOString();
+  return NextResponse.json({ members: segment.members });
+}

--- a/src/app/api/segments/[id]/route.ts
+++ b/src/app/api/segments/[id]/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { getSessionOrg } from "@/lib/auth";
+import { db } from "@/lib/store";
+
+const updateSchema = z.object({
+  name: z.string().optional(),
+  dslJson: z.any().optional(),
+});
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const segment = db.segments.get(params.id);
+  if (!segment) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (segment.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return NextResponse.json({ segment, members: segment.members });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const segment = db.segments.get(params.id);
+  if (!segment) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (segment.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  Object.assign(segment, parsed.data, { updatedAt: new Date().toISOString() });
+  db.segments.set(segment.id, segment);
+  return NextResponse.json({ segment });
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const segment = db.segments.get(params.id);
+  if (!segment) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (segment.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  db.segments.delete(segment.id);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/segments/route.ts
+++ b/src/app/api/segments/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { getSessionOrg } from "@/lib/auth";
+import { db, Segment } from "@/lib/store";
+
+const PAGE_SIZE = 10;
+
+export async function GET(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { searchParams } = new URL(req.url);
+  const cursor = searchParams.get("cursor") || undefined;
+
+  const segments = Array.from(db.segments.values()).filter(
+    (s) => s.orgId === orgId
+  );
+  segments.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  const start = cursor ? segments.findIndex((s) => s.id === cursor) + 1 : 0;
+  const page = segments.slice(start, start + PAGE_SIZE);
+  const nextCursor =
+    start + PAGE_SIZE < segments.length ? page[page.length - 1].id : null;
+  return NextResponse.json({ segments: page, nextCursor });
+}
+
+const createSchema = z.object({
+  name: z.string(),
+  dslJson: z.any(),
+});
+
+export async function POST(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  const { name, dslJson } = parsed.data;
+  const now = new Date().toISOString();
+  const segment: Segment = {
+    id: randomUUID(),
+    orgId,
+    name,
+    dslJson,
+    members: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.segments.set(segment.id, segment);
+  return NextResponse.json({ segment });
+}

--- a/src/app/api/sequences/[id]/route.ts
+++ b/src/app/api/sequences/[id]/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { getSessionOrg } from "@/lib/auth";
+import { db, SequenceStep } from "@/lib/store";
+
+const stepSchema = z.object({
+  id: z.string().optional(),
+  delayHours: z.number(),
+  contentJson: z.any(),
+  order: z.number(),
+});
+
+const updateSchema = z.object({
+  name: z.string().optional(),
+  segmentId: z.string().optional(),
+  steps: z.array(stepSchema).optional(),
+});
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const sequence = db.sequences.get(params.id);
+  if (!sequence) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (sequence.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return NextResponse.json({ sequence });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const sequence = db.sequences.get(params.id);
+  if (!sequence) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (sequence.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = updateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  if (parsed.data.segmentId) {
+    const seg = db.segments.get(parsed.data.segmentId);
+    if (!seg) {
+      return NextResponse.json({ error: "Segment not found" }, { status: 422 });
+    }
+    if (seg.orgId !== orgId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+  if (parsed.data.steps) {
+    const steps: SequenceStep[] = parsed.data.steps.map((s) => ({
+      id: s.id || randomUUID(),
+      delayHours: s.delayHours,
+      contentJson: s.contentJson,
+      order: s.order,
+    }));
+    sequence.steps = steps;
+  }
+  if (parsed.data.name !== undefined) sequence.name = parsed.data.name;
+  if (parsed.data.segmentId !== undefined)
+    sequence.segmentId = parsed.data.segmentId;
+  sequence.updatedAt = new Date().toISOString();
+  db.sequences.set(sequence.id, sequence);
+  return NextResponse.json({ sequence });
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const sequence = db.sequences.get(params.id);
+  if (!sequence) {
+    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+  }
+  if (sequence.orgId !== orgId) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  db.sequences.delete(sequence.id);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/sequences/route.ts
+++ b/src/app/api/sequences/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { randomUUID } from "crypto";
+import { getSessionOrg } from "@/lib/auth";
+import { db, Sequence, SequenceStep } from "@/lib/store";
+
+const PAGE_SIZE = 10;
+
+const stepSchema = z.object({
+  delayHours: z.number(),
+  contentJson: z.any(),
+  order: z.number(),
+});
+
+const createSchema = z.object({
+  name: z.string(),
+  segmentId: z.string().optional(),
+  steps: z.array(stepSchema),
+});
+
+export async function GET(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const { searchParams } = new URL(req.url);
+  const cursor = searchParams.get("cursor") || undefined;
+  const sequences = Array.from(db.sequences.values()).filter(
+    (s) => s.orgId === orgId
+  );
+  sequences.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  const start = cursor ? sequences.findIndex((s) => s.id === cursor) + 1 : 0;
+  const page = sequences.slice(start, start + PAGE_SIZE);
+  const nextCursor =
+    start + PAGE_SIZE < sequences.length ? page[page.length - 1].id : null;
+  return NextResponse.json({ sequences: page, nextCursor });
+}
+
+export async function POST(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = await req.json().catch(() => null);
+  const parsed = createSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    );
+  }
+  const { name, steps, segmentId } = parsed.data;
+  if (segmentId) {
+    const seg = db.segments.get(segmentId);
+    if (!seg) {
+      return NextResponse.json({ error: "Segment not found" }, { status: 422 });
+    }
+    if (seg.orgId !== orgId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+  }
+  const now = new Date().toISOString();
+  const seqSteps: SequenceStep[] = steps.map((s) => ({
+    id: randomUUID(),
+    ...s,
+  }));
+  const sequence: Sequence = {
+    id: randomUUID(),
+    orgId,
+    name,
+    steps: seqSteps,
+    segmentId,
+    createdAt: now,
+    updatedAt: now,
+  };
+  db.sequences.set(sequence.id, sequence);
+  return NextResponse.json({ sequence });
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,0 +1,53 @@
+export interface Segment {
+  id: string;
+  orgId: string;
+  name: string;
+  dslJson: unknown;
+  members: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CampaignStatus = "DRAFT" | "SCHEDULED" | "SENT";
+
+export interface Campaign {
+  id: string;
+  orgId: string;
+  name: string;
+  contentJson: unknown;
+  status: CampaignStatus;
+  sendAt?: string;
+  segmentId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SequenceStep {
+  id: string;
+  delayHours: number;
+  contentJson: unknown;
+  order: number;
+}
+
+export interface Sequence {
+  id: string;
+  orgId: string;
+  name: string;
+  steps: SequenceStep[];
+  segmentId?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface AutosaveEntry {
+  key: string;
+  data: unknown;
+  updatedAt: string;
+}
+
+export const db = {
+  segments: new Map<string, Segment>(),
+  campaigns: new Map<string, Campaign>(),
+  sequences: new Map<string, Sequence>(),
+  autosave: new Map<string, Map<string, AutosaveEntry>>() /* orgId -> key -> entry */,
+};


### PR DESCRIPTION
## Summary
- add in-memory store and marketing API handlers for segments, campaigns, sequences
- support autosave endpoint for per-org draft data
- validate requests with zod and enforce org scoping with cursor pagination

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7435e74a8832db74337279aecf4ed