### PR TITLE
feat(segments): add segments UI section

### DIFF
--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -3,13 +3,15 @@ import { SiteHeader } from "@/components/site-header"
 
 import { contacts } from "./data"
 import { ContactsDataTable } from "./contacts-data-table"
+import { SegmentsSection } from "@/components/segments/SegmentsSection"
 
 export default function ContactsPage() {
   return (
     <SidebarInset>
       <SiteHeader title="Contacts" />
-      <div className="p-4">
+      <div className="p-4 space-y-8">
         <ContactsDataTable data={contacts} />
+        <SegmentsSection />
       </div>
     </SidebarInset>
   )

--- a/src/components/segments/SegmentCard.tsx
+++ b/src/components/segments/SegmentCard.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import type { SegmentDraft } from './SegmentEditorSheet'
+
+interface SegmentCardProps {
+  segment: SegmentDraft
+  onEdit: () => void
+}
+
+export function SegmentCard({ segment, onEdit }: SegmentCardProps) {
+  return (
+    <Card className="@container/card cursor-pointer" onClick={onEdit}>
+      <CardHeader>
+        <CardTitle className="text-base font-medium">{segment.name || 'Untitled'}</CardTitle>
+      </CardHeader>
+      {segment.subtitle && (
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{segment.subtitle}</p>
+        </CardContent>
+      )}
+    </Card>
+  )
+}

--- a/src/components/segments/SegmentEditorSheet.tsx
+++ b/src/components/segments/SegmentEditorSheet.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
+import { Input } from '@/components/ui/input'
+import { Badge } from '@/components/ui/badge'
+import { SegmentFiltersBuilder, SegmentFilter } from './SegmentFiltersBuilder'
+
+export interface SegmentDraft {
+  id: string
+  name: string
+  subtitle: string
+  category: string
+  filtersMode: 'any' | 'all'
+  filters: SegmentFilter[]
+}
+
+interface SegmentEditorSheetProps {
+  open: boolean
+  segment: SegmentDraft | null
+  onClose: () => void
+  onChange: (segment: SegmentDraft) => void
+}
+
+function AutosaveBadge({ saved }: { saved: boolean }) {
+  return <Badge variant="outline">{saved ? 'Saved' : 'Saving...'}</Badge>
+}
+
+export function SegmentEditorSheet({ open, segment, onClose, onChange }: SegmentEditorSheetProps) {
+  const [draft, setDraft] = useState<SegmentDraft | null>(segment)
+  const [saved, setSaved] = useState(true)
+
+  useEffect(() => {
+    setDraft(segment)
+  }, [segment])
+
+  useEffect(() => {
+    if (!draft) return
+    setSaved(false)
+    const t = setTimeout(() => {
+      onChange(draft)
+      setSaved(true)
+    }, 1000)
+    return () => clearTimeout(t)
+  }, [draft, onChange])
+
+  if (!draft) return null
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent className="flex flex-col gap-4">
+        <SheetHeader>
+          <div className="flex items-center justify-between">
+            <SheetTitle>{draft.name || 'New Segment'}</SheetTitle>
+            <AutosaveBadge saved={saved} />
+          </div>
+          <SheetDescription>Define your contact segment.</SheetDescription>
+        </SheetHeader>
+        <div className="flex flex-col gap-4 overflow-y-auto">
+          <Input
+            placeholder="Title"
+            value={draft.name}
+            onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+          />
+          <Input
+            placeholder="Subtitle"
+            value={draft.subtitle}
+            onChange={(e) => setDraft({ ...draft, subtitle: e.target.value })}
+          />
+          <Input
+            placeholder="Category"
+            value={draft.category}
+            onChange={(e) => setDraft({ ...draft, category: e.target.value })}
+          />
+          <SegmentFiltersBuilder
+            value={{ mode: draft.filtersMode, filters: draft.filters }}
+            onChange={(v) => setDraft({ ...draft, filtersMode: v.mode, filters: v.filters })}
+          />
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src/components/segments/SegmentEmptyCard.tsx
+++ b/src/components/segments/SegmentEmptyCard.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+export function SegmentEmptyCard({ onCreate }: { onCreate: () => void }) {
+  return (
+    <Card className="flex h-full items-center justify-center" data-empty>
+      <CardContent className="flex flex-col items-center justify-center gap-4 p-6 text-center">
+        <p className="text-sm text-muted-foreground">No segments yet</p>
+        <Button onClick={onCreate}>Create segment</Button>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/segments/SegmentFiltersBuilder.tsx
+++ b/src/components/segments/SegmentFiltersBuilder.tsx
@@ -1,0 +1,93 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
+
+export type SegmentFilter = {
+  id: string
+  type: 'tag' | 'emailDomain' | 'date'
+  value: string
+}
+
+interface BuilderValue {
+  mode: 'any' | 'all'
+  filters: SegmentFilter[]
+}
+
+interface SegmentFiltersBuilderProps {
+  value: BuilderValue
+  onChange: (value: BuilderValue) => void
+}
+
+export function SegmentFiltersBuilder({ value, onChange }: SegmentFiltersBuilderProps) {
+  const { mode, filters } = value
+
+  function updateFilter(id: string, patch: Partial<SegmentFilter>) {
+    onChange({
+      mode,
+      filters: filters.map((f) => (f.id === id ? { ...f, ...patch } : f)),
+    })
+  }
+
+  return (
+    <div className="space-y-4">
+      <Select value={mode} onValueChange={(v) => onChange({ mode: v as 'any' | 'all', filters })}>
+        <SelectTrigger className="w-32">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="any">Any</SelectItem>
+          <SelectItem value="all">All</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <div className="space-y-2">
+        {filters.map((filter) => (
+          <div key={filter.id} className="flex items-center gap-2">
+            <Select
+              value={filter.type}
+              onValueChange={(v) => updateFilter(filter.id, { type: v as SegmentFilter['type'] })}
+            >
+              <SelectTrigger className="w-40">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="tag">Tag</SelectItem>
+                <SelectItem value="emailDomain">Email Domain</SelectItem>
+                <SelectItem value="date">Date</SelectItem>
+              </SelectContent>
+            </Select>
+            <Input
+              className="flex-1"
+              value={filter.value}
+              onChange={(e) => updateFilter(filter.id, { value: e.target.value })}
+              placeholder="Value"
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() =>
+                onChange({ mode, filters: filters.filter((f) => f.id !== filter.id) })
+              }
+            >
+              ×
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <Button
+        variant="outline"
+        onClick={() =>
+          onChange({
+            mode,
+            filters: [...filters, { id: Date.now().toString(), type: 'tag', value: '' }],
+          })
+        }
+      >
+        Add filter
+      </Button>
+    </div>
+  )
+}

--- a/src/components/segments/SegmentsSection.tsx
+++ b/src/components/segments/SegmentsSection.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState } from 'react'
+import { SegmentCard } from './SegmentCard'
+import { SegmentEmptyCard } from './SegmentEmptyCard'
+import { SegmentEditorSheet, SegmentDraft } from './SegmentEditorSheet'
+
+export function SegmentsSection() {
+  const [segments, setSegments] = useState<SegmentDraft[]>([])
+  const [editing, setEditing] = useState<SegmentDraft | null>(null)
+
+  function handleChange(segment: SegmentDraft) {
+    setSegments((prev) => {
+      const exists = prev.find((s) => s.id === segment.id)
+      if (exists) {
+        return prev.map((s) => (s.id === segment.id ? segment : s))
+      }
+      return [...prev, segment]
+    })
+  }
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold">Segments</h2>
+      {segments.length === 0 ? (
+        <SegmentEmptyCard
+          onCreate={() =>
+            setEditing({
+              id: Date.now().toString(),
+              name: '',
+              subtitle: '',
+              category: '',
+              filtersMode: 'any',
+              filters: [],
+            })
+          }
+        />
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {segments.map((segment) => (
+            <SegmentCard key={segment.id} segment={segment} onEdit={() => setEditing(segment)} />
+          ))}
+          <SegmentEmptyCard
+            onCreate={() =>
+              setEditing({
+                id: Date.now().toString(),
+                name: '',
+                subtitle: '',
+                category: '',
+                filtersMode: 'any',
+                filters: [],
+              })
+            }
+          />
+        </div>
+      )}
+      <SegmentEditorSheet
+        open={!!editing}
+        segment={editing}
+        onClose={() => setEditing(null)}
+        onChange={handleChange}
+      />
+    </section>
+  )
+}

--- a/src/components/shared/BreadcrumbPortal.tsx
+++ b/src/components/shared/BreadcrumbPortal.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+export function BreadcrumbPortal({ children }: { children: React.ReactNode }) {
+  const [container, setContainer] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    let el = document.getElementById('breadcrumb-portal')
+    if (!el) {
+      el = document.createElement('div')
+      el.id = 'breadcrumb-portal'
+      document.body.appendChild(el)
+    }
+    setContainer(el)
+  }, [])
+
+  return container ? createPortal(children, container) : null
+}


### PR DESCRIPTION
## Summary
- add SegmentsSection with cards, empty state, editor and filters builder
- introduce BreadcrumbPortal for header breadcrumb rendering
- show segments below contacts table on contacts page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7436c1824832db6e0c7bbadbf598d