### PR TITLE
feat: add campaign composer

### DIFF
--- a/src/app/contacts/campaigns/[campaignId]/page.tsx
+++ b/src/app/contacts/campaigns/[campaignId]/page.tsx
@@ -1,0 +1,14 @@
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { CampaignComposer } from "@/components/campaigns/CampaignComposer"
+
+export default function CampaignPage({ params }: { params: { campaignId: string } }) {
+  return (
+    <SidebarInset>
+      <SiteHeader title="Campaign" />
+      <div className="p-4">
+        <CampaignComposer campaignId={params.campaignId} />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/app/contacts/campaigns/data.ts
+++ b/src/app/contacts/campaigns/data.ts
@@ -1,0 +1,24 @@
+import { z } from "zod"
+
+export const campaignSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(["DRAFT", "SCHEDULED", "SENT"]),
+  scheduledAt: z.string().optional(),
+})
+
+export type Campaign = z.infer<typeof campaignSchema>
+
+export const campaigns: Campaign[] = [
+  {
+    id: "1",
+    name: "Welcome Series",
+    status: "DRAFT",
+  },
+  {
+    id: "2",
+    name: "Spring Fundraiser",
+    status: "SCHEDULED",
+    scheduledAt: "2025-05-01T09:00",
+  },
+]

--- a/src/app/contacts/campaigns/new/page.tsx
+++ b/src/app/contacts/campaigns/new/page.tsx
@@ -1,0 +1,16 @@
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { CampaignComposer } from "@/components/campaigns/CampaignComposer"
+
+export default function NewCampaignPage() {
+  const id = crypto.randomUUID()
+
+  return (
+    <SidebarInset>
+      <SiteHeader title="New Campaign" />
+      <div className="p-4">
+        <CampaignComposer campaignId={id} />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/app/contacts/campaigns/page.tsx
+++ b/src/app/contacts/campaigns/page.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link"
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { Button } from "@/components/ui/button"
+
+import { campaigns } from "./data"
+
+export default function CampaignsPage() {
+  return (
+    <SidebarInset>
+      <SiteHeader title="Campaigns" />
+      <div className="p-4 space-y-4">
+        <div>
+          <Button asChild>
+            <Link href="/contacts/campaigns/new">New Campaign</Link>
+          </Button>
+        </div>
+        <table className="w-full text-sm">
+          <thead className="text-left">
+            <tr>
+              <th className="p-2">Name</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Scheduled</th>
+            </tr>
+          </thead>
+          <tbody>
+            {campaigns.map((c) => (
+              <tr key={c.id} className="border-t">
+                <td className="p-2">
+                  <Link href={`/contacts/campaigns/${c.id}`}>{c.name}</Link>
+                </td>
+                <td className="p-2">{c.status}</td>
+                <td className="p-2">{c.scheduledAt ?? "-"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/components/campaigns/Blocks/HeadingBlock.tsx
+++ b/src/components/campaigns/Blocks/HeadingBlock.tsx
@@ -1,0 +1,19 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+import type { EmailBlock } from "@/lib/email/render"
+
+interface BlockProps {
+  block: EmailBlock
+  onChange: (block: EmailBlock) => void
+}
+
+export function HeadingBlock({ block, onChange }: BlockProps) {
+  return (
+    <Input
+      value={block.content}
+      onChange={(e) => onChange({ ...block, content: e.target.value })}
+      placeholder="Heading text"
+    />
+  )
+}

--- a/src/components/campaigns/Blocks/ParagraphBlock.tsx
+++ b/src/components/campaigns/Blocks/ParagraphBlock.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import { Textarea } from "@/components/ui/textarea"
+import type { EmailBlock } from "@/lib/email/render"
+
+interface BlockProps {
+  block: EmailBlock
+  onChange: (block: EmailBlock) => void
+}
+
+export function ParagraphBlock({ block, onChange }: BlockProps) {
+  return (
+    <Textarea
+      value={block.content}
+      onChange={(e) => onChange({ ...block, content: e.target.value })}
+      placeholder="Paragraph text"
+      className="min-h-[100px]"
+    />
+  )
+}

--- a/src/components/campaigns/CampaignComposer.tsx
+++ b/src/components/campaigns/CampaignComposer.tsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { EmailBlock, renderEmail } from "@/lib/email/render"
+
+import { HeadingBlock } from "./Blocks/HeadingBlock"
+import { ParagraphBlock } from "./Blocks/ParagraphBlock"
+
+interface CampaignComposerProps {
+  campaignId: string
+}
+
+export function CampaignComposer({ campaignId }: CampaignComposerProps) {
+  const storageKey = `campaign-${campaignId}`
+
+  const [title, setTitle] = useState("")
+  const [blocks, setBlocks] = useState<EmailBlock[]>([])
+  const [status, setStatus] = useState<"DRAFT" | "SCHEDULED">("DRAFT")
+  const [scheduledAt, setScheduledAt] = useState("")
+
+  // load draft
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const saved = localStorage.getItem(storageKey)
+    if (saved) {
+      try {
+        const data = JSON.parse(saved)
+        setTitle(data.title || "")
+        setBlocks(data.blocks || [])
+        setStatus(data.status || "DRAFT")
+        setScheduledAt(data.scheduledAt || "")
+      } catch {}
+    }
+  }, [storageKey])
+
+  // autosave
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const data = { title, blocks, status, scheduledAt }
+    localStorage.setItem(storageKey, JSON.stringify(data))
+  }, [title, blocks, status, scheduledAt, storageKey])
+
+  const addBlock = (type: EmailBlock["type"]) => {
+    setBlocks([...blocks, { id: crypto.randomUUID(), type, content: "" }])
+  }
+
+  const updateBlock = (index: number, block: EmailBlock) => {
+    const next = [...blocks]
+    next[index] = block
+    setBlocks(next)
+  }
+
+  const removeBlock = (index: number) => {
+    setBlocks(blocks.filter((_, i) => i !== index))
+  }
+
+  const moveBlock = (index: number, delta: number) => {
+    const next = [...blocks]
+    const newIndex = index + delta
+    if (newIndex < 0 || newIndex >= next.length) return
+    const [item] = next.splice(index, 1)
+    next.splice(newIndex, 0, item)
+    setBlocks(next)
+  }
+
+  const previewHtml = useMemo(() => renderEmail(blocks), [blocks])
+
+  const handleSchedule = () => {
+    if (scheduledAt) {
+      setStatus("SCHEDULED")
+    }
+  }
+
+  const renderBlock = (block: EmailBlock, index: number) => {
+    const common = { block, onChange: (b: EmailBlock) => updateBlock(index, b) }
+    switch (block.type) {
+      case "heading":
+        return <HeadingBlock {...common} />
+      case "paragraph":
+        return <ParagraphBlock {...common} />
+      default:
+        return null
+    }
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <div className="space-y-4">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Campaign title"
+        />
+        {blocks.map((block, index) => (
+          <div key={block.id} className="space-y-2 rounded border p-2">
+            {renderBlock(block, index)}
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => moveBlock(index, -1)}
+              >
+                Up
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => moveBlock(index, 1)}
+              >
+                Down
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => removeBlock(index)}
+              >
+                Remove
+              </Button>
+            </div>
+          </div>
+        ))}
+        <div className="flex gap-2">
+          <Button type="button" onClick={() => addBlock("heading")}>
+            Add Heading
+          </Button>
+          <Button type="button" onClick={() => addBlock("paragraph")}>
+            Add Paragraph
+          </Button>
+        </div>
+        <div className="space-y-2">
+          <Input
+            type="datetime-local"
+            value={scheduledAt}
+            onChange={(e) => setScheduledAt(e.target.value)}
+          />
+          <Button type="button" onClick={handleSchedule}>
+            Schedule
+          </Button>
+          <div className="text-sm text-muted-foreground">Status: {status}</div>
+        </div>
+      </div>
+      <div className="rounded border p-4">
+        <div dangerouslySetInnerHTML={{ __html: previewHtml }} />
+      </div>
+    </div>
+  )
+}

--- a/src/lib/email/render.ts
+++ b/src/lib/email/render.ts
@@ -1,0 +1,30 @@
+export type EmailBlock = {
+  id: string
+  type: "heading" | "paragraph"
+  content: string
+}
+
+function escapeHtml(str: string) {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;")
+}
+
+export function renderEmail(blocks: EmailBlock[]): string {
+  return blocks
+    .map((block) => {
+      const content = escapeHtml(block.content)
+      switch (block.type) {
+        case "heading":
+          return `<h1>${content}</h1>`
+        case "paragraph":
+          return `<p>${content}</p>`
+        default:
+          return ""
+      }
+    })
+    .join("\n")
+}


### PR DESCRIPTION
## Summary
- add campaign list and composer pages
- implement block-based campaign composer with autosave and preview
- render email blocks to HTML

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a744409d70832d9d63cf8b834af412