### PR TITLE
feat: add campaign scheduler stub and email queue

### DIFF
--- a/src/app/api/campaigns/[id]/route.ts
+++ b/src/app/api/campaigns/[id]/route.ts
@@ -8,7 +8,7 @@ const updateSchema = z.object({
   contentJson: z.any().optional(),
   segmentId: z.string().optional(),
   sendAt: z.string().optional(),
-  status: z.enum(["DRAFT", "SCHEDULED", "SENT"]).optional(),
+  status: z.enum(["DRAFT", "SCHEDULED", "SENDING", "SENT"]).optional(),
 });
 
 export async function GET(

--- a/src/app/contacts/campaigns/data.ts
+++ b/src/app/contacts/campaigns/data.ts
@@ -3,7 +3,7 @@ import { z } from "zod"
 export const campaignSchema = z.object({
   id: z.string(),
   name: z.string(),
-  status: z.enum(["DRAFT", "SCHEDULED", "SENT"]),
+  status: z.enum(["DRAFT", "SCHEDULED", "SENDING", "SENT"]),
   scheduledAt: z.string().optional(),
 })
 

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -8,7 +8,11 @@ export interface Segment {
   updatedAt: string;
 }
 
-export type CampaignStatus = "DRAFT" | "SCHEDULED" | "SENT";
+export type CampaignStatus =
+  | "DRAFT"
+  | "SCHEDULED"
+  | "SENDING"
+  | "SENT";
 
 export interface Campaign {
   id: string;

--- a/src/packages/emailer/README.md
+++ b/src/packages/emailer/README.md
@@ -1,3 +1,6 @@
 # Emailer Package
 
 Email templating utilities placeholder.
+
+Provides a minimal queue interface that currently logs payloads and includes a
+placeholder for metrics collection.

--- a/src/packages/emailer/index.ts
+++ b/src/packages/emailer/index.ts
@@ -1,0 +1,1 @@
+export * from "./queue";

--- a/src/packages/emailer/queue.ts
+++ b/src/packages/emailer/queue.ts
@@ -1,0 +1,10 @@
+export interface QueuePayload {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export async function enqueueEmail(payload: QueuePayload): Promise<void> {
+  console.log("Enqueue email", payload);
+  // TODO: record metrics
+}

--- a/supabase/functions/scheduler/index.ts
+++ b/supabase/functions/scheduler/index.ts
@@ -1,0 +1,43 @@
+import { serve } from "https://deno.land/std/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+serve(async (_req) => {
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  const supabase = createClient(supabaseUrl, serviceRoleKey);
+  const now = new Date().toISOString();
+
+  const { data: campaigns, error } = await supabase
+    .from("campaigns")
+    .select("id")
+    .eq("status", "SCHEDULED")
+    .lte("send_at", now);
+
+  if (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ error: error.message }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  if (campaigns && campaigns.length > 0) {
+    const ids = campaigns.map((c: { id: string }) => c.id);
+    const { error: updateError } = await supabase
+      .from("campaigns")
+      .update({ status: "SENDING", updated_at: now })
+      .in("id", ids);
+    if (updateError) {
+      console.error(updateError);
+      return new Response(JSON.stringify({ error: updateError.message }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+  }
+
+  return new Response(
+    JSON.stringify({ updated: campaigns ? campaigns.length : 0 }),
+    { headers: { "Content-Type": "application/json" } }
+  );
+});


### PR DESCRIPTION
## Summary
- add Supabase edge function to mark due campaigns as SENDING
- expand campaign status types and API schema to include SENDING
- introduce email queue stub that logs payloads and leaves placeholder for metrics

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a74d350ce4832db60e2c89036859b3