### PR TITLE
feat: add contact sequences editor and pages

### DIFF
--- a/src/app/contacts/sequences/[sequenceId]/page.tsx
+++ b/src/app/contacts/sequences/[sequenceId]/page.tsx
@@ -1,0 +1,18 @@
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SequenceEditor } from "@/components/sequences/SequenceEditor"
+
+export default function SequenceEditorPage({
+  params,
+}: {
+  params: { sequenceId: string }
+}) {
+  return (
+    <SidebarInset>
+      <SiteHeader title="Edit Sequence" />
+      <div className="p-4">
+        <SequenceEditor sequenceId={params.sequenceId} />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/app/contacts/sequences/new/page.tsx
+++ b/src/app/contacts/sequences/new/page.tsx
@@ -1,0 +1,16 @@
+import { randomUUID } from "crypto"
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { SequenceEditor } from "@/components/sequences/SequenceEditor"
+
+export default function NewSequencePage() {
+  const id = randomUUID()
+  return (
+    <SidebarInset>
+      <SiteHeader title="New Sequence" />
+      <div className="p-4">
+        <SequenceEditor sequenceId={id} />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/app/contacts/sequences/page.tsx
+++ b/src/app/contacts/sequences/page.tsx
@@ -1,0 +1,67 @@
+import * as React from "react"
+import Link from "next/link"
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { Button } from "@/components/ui/button"
+
+function SequenceList() {
+  "use client"
+  const [sequences, setSequences] = React.useState<
+    { id: string; name: string; status: string }
+  >([])
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return
+    const seqs: { id: string; name: string; status: string }[] = []
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i)
+      if (key && key.startsWith("sequence-")) {
+        try {
+          const data = JSON.parse(localStorage.getItem(key) || "{}")
+          seqs.push({
+            id: key.replace("sequence-", ""),
+            name: data.name || "Untitled",
+            status: data.status || "DRAFT",
+          })
+        } catch {}
+      }
+    }
+    setSequences(seqs)
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <Button asChild>
+        <Link href="/contacts/sequences/new">New Sequence</Link>
+      </Button>
+      {sequences.length === 0 ? (
+        <div className="text-sm text-muted-foreground">No sequences yet.</div>
+      ) : (
+        <ul className="space-y-2">
+          {sequences.map((seq) => (
+            <li key={seq.id}>
+              <Link
+                href={`/contacts/sequences/${seq.id}`}
+                className="underline"
+              >
+                {seq.name}
+              </Link>
+              <span className="text-xs text-muted-foreground"> ({seq.status})</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default function SequencesPage() {
+  return (
+    <SidebarInset>
+      <SiteHeader title="Sequences" />
+      <div className="p-4">
+        <SequenceList />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/components/sequences/SequenceEditor.tsx
+++ b/src/components/sequences/SequenceEditor.tsx
@@ -1,0 +1,154 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
+import { Label } from "@/components/ui/label"
+
+interface StepDraft {
+  id: string
+  delay: string
+  content: string
+}
+
+export interface SequenceEditorProps {
+  sequenceId: string
+}
+
+export function SequenceEditor({ sequenceId }: SequenceEditorProps) {
+  const storageKey = `sequence-${sequenceId}`
+  const [name, setName] = useState("")
+  const [status, setStatus] = useState<"DRAFT" | "ACTIVE" | "PAUSED">("DRAFT")
+  const [steps, setSteps] = useState<StepDraft[]>([])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const raw = localStorage.getItem(storageKey)
+    if (raw) {
+      try {
+        const data = JSON.parse(raw)
+        setName(data.name || "")
+        setStatus(data.status || "DRAFT")
+        setSteps(data.steps || [])
+      } catch {}
+    }
+  }, [storageKey])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const data = { id: sequenceId, name, status, steps }
+    localStorage.setItem(storageKey, JSON.stringify(data))
+  }, [name, status, steps, storageKey, sequenceId])
+
+  const addStep = () => {
+    setSteps([...steps, { id: crypto.randomUUID(), delay: "0", content: "" }])
+  }
+
+  const updateStep = (index: number, step: StepDraft) => {
+    const next = [...steps]
+    next[index] = step
+    setSteps(next)
+  }
+
+  const removeStep = (index: number) => {
+    setSteps(steps.filter((_, i) => i !== index))
+  }
+
+  const moveStep = (index: number, delta: number) => {
+    const next = [...steps]
+    const newIndex = index + delta
+    if (newIndex < 0 || newIndex >= next.length) return
+    const [item] = next.splice(index, 1)
+    next.splice(newIndex, 0, item)
+    setSteps(next)
+  }
+
+  return (
+    <div className="space-y-4">
+      <Input
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Sequence name"
+      />
+      <div>
+        <div className="mb-2 font-medium">Status</div>
+        <RadioGroup
+          value={status}
+          onValueChange={(v: "DRAFT" | "ACTIVE" | "PAUSED") => setStatus(v)}
+          className="flex gap-4"
+        >
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="DRAFT" id="seq-status-draft" />
+            <Label htmlFor="seq-status-draft">Draft</Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="ACTIVE" id="seq-status-active" />
+            <Label htmlFor="seq-status-active">Active</Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="PAUSED" id="seq-status-paused" />
+            <Label htmlFor="seq-status-paused">Paused</Label>
+          </div>
+        </RadioGroup>
+      </div>
+      {steps.map((step, index) => {
+        const delayNum = Number(step.delay)
+        const delayError = isNaN(delayNum) || delayNum < 0
+        return (
+          <div key={step.id} className="space-y-2 rounded border p-2">
+            <div className="space-y-2">
+              <Input
+                type="number"
+                value={step.delay}
+                onChange={(e) =>
+                  updateStep(index, { ...step, delay: e.target.value })
+                }
+                placeholder="Delay in hours"
+              />
+              {delayError && (
+                <p className="text-sm text-red-500">
+                  Delay must be a non-negative number
+                </p>
+              )}
+              <Textarea
+                value={step.content}
+                onChange={(e) =>
+                  updateStep(index, { ...step, content: e.target.value })
+                }
+                placeholder="Step content"
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => moveStep(index, -1)}
+              >
+                Up
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => moveStep(index, 1)}
+              >
+                Down
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => removeStep(index)}
+              >
+                Remove
+              </Button>
+            </div>
+          </div>
+        )
+      })}
+      <Button type="button" onClick={addStep}>
+        Add Step
+      </Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add sequence editor with step ordering, delay validation, and status toggles
- list and edit contact sequences with new, edit, and overview pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74d2d2114832dabaf151dfdd460ab