### PR TITLE
test: add vitest setup and coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "test": "vitest",
     "db:push": "prisma db push --schema packages/db/prisma/schema.prisma",
     "db:migrate": "prisma migrate dev --schema packages/db/prisma/schema.prisma",
     "db:studio": "prisma studio --schema packages/db/prisma/schema.prisma"
@@ -75,11 +76,16 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
     "eslint": "^9",
     "eslint-config-next": "15.4.6",
+    "jsdom": "^24.1.3",
     "prisma": "^6.14.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.6",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^2.1.2"
   }
 }

--- a/src/lib/email/render.ts
+++ b/src/lib/email/render.ts
@@ -13,7 +13,7 @@ function escapeHtml(str: string) {
     .replace(/'/g, "&#039;")
 }
 
-export function renderEmail(blocks: EmailBlock[]): string {
+export function renderBlocksToHtml(blocks: EmailBlock[]): string {
   return blocks
     .map((block) => {
       const content = escapeHtml(block.content)
@@ -28,3 +28,5 @@ export function renderEmail(blocks: EmailBlock[]): string {
     })
     .join("\n")
 }
+
+export { renderBlocksToHtml as renderEmail }

--- a/src/tests/api/campaigns.test.ts
+++ b/src/tests/api/campaigns.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST as send } from '@/app/api/campaigns/[id]/send/route'
+import { db, Campaign } from '@/lib/store'
+import { getSessionOrg } from '@/lib/auth'
+
+vi.mock('@/lib/auth', () => ({ getSessionOrg: vi.fn() }))
+
+beforeEach(() => {
+  db.campaigns.clear()
+  vi.mocked(getSessionOrg).mockReset()
+})
+
+describe('campaign schedule guard', () => {
+  it('schedules future send as SCHEDULED', async () => {
+    const campaign: Campaign = {
+      id: 'c1',
+      orgId: 'org1',
+      name: 'Camp',
+      contentJson: {},
+      status: 'DRAFT',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+    db.campaigns.set(campaign.id, campaign)
+    vi.mocked(getSessionOrg).mockResolvedValue('org1')
+
+    const future = new Date(Date.now() + 3600_000).toISOString()
+    const req = new NextRequest('http://test.com', {
+      method: 'POST',
+      body: JSON.stringify({ sendAt: future }),
+    })
+    const res = await send(req, { params: { id: 'c1' } })
+    const data = await res.json()
+    expect(data.campaign.status).toBe('SCHEDULED')
+  })
+
+  it('sends immediately when past date', async () => {
+    const campaign: Campaign = {
+      id: 'c2',
+      orgId: 'org1',
+      name: 'Camp',
+      contentJson: {},
+      status: 'DRAFT',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+    db.campaigns.set(campaign.id, campaign)
+    vi.mocked(getSessionOrg).mockResolvedValue('org1')
+
+    const past = new Date(Date.now() - 3600_000).toISOString()
+    const req = new NextRequest('http://test.com', {
+      method: 'POST',
+      body: JSON.stringify({ sendAt: past }),
+    })
+    const res = await send(req, { params: { id: 'c2' } })
+    const data = await res.json()
+    expect(data.campaign.status).toBe('SENT')
+  })
+})

--- a/src/tests/api/members.test.ts
+++ b/src/tests/api/members.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { POST, DELETE } from '@/app/api/segments/[id]/members/route'
+import { db, Segment } from '@/lib/store'
+import { getSessionOrg } from '@/lib/auth'
+
+vi.mock('@/lib/auth', () => ({ getSessionOrg: vi.fn() }))
+
+beforeEach(() => {
+  db.segments.clear()
+  vi.mocked(getSessionOrg).mockReset()
+})
+
+describe('segment members API', () => {
+  it('adds and removes members', async () => {
+    const segment: Segment = {
+      id: 's1',
+      orgId: 'org1',
+      name: 'Seg',
+      dslJson: {},
+      members: [],
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+    db.segments.set(segment.id, segment)
+    vi.mocked(getSessionOrg).mockResolvedValue('org1')
+
+    const addReq = new NextRequest('http://test.com', {
+      method: 'POST',
+      body: JSON.stringify({ contactIds: ['a', 'b'] }),
+    })
+    const addRes = await POST(addReq, { params: { id: 's1' } })
+    expect(addRes.status).toBe(200)
+    const addData = await addRes.json()
+    expect(addData.members).toEqual(['a', 'b'])
+
+    const delReq = new NextRequest('http://test.com', {
+      method: 'DELETE',
+      body: JSON.stringify({ contactIds: ['a'] }),
+    })
+    const delRes = await DELETE(delReq, { params: { id: 's1' } })
+    expect(delRes.status).toBe(200)
+    const delData = await delRes.json()
+    expect(delData.members).toEqual(['b'])
+  })
+})

--- a/src/tests/api/segments.test.ts
+++ b/src/tests/api/segments.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { GET, POST } from '@/app/api/segments/route'
+import { db } from '@/lib/store'
+import { getSessionOrg } from '@/lib/auth'
+
+vi.mock('@/lib/auth', () => ({ getSessionOrg: vi.fn() }))
+
+beforeEach(() => {
+  db.segments.clear()
+  vi.mocked(getSessionOrg).mockReset()
+})
+
+describe('segments API', () => {
+  it('rejects unauthorized access', async () => {
+    vi.mocked(getSessionOrg).mockResolvedValue(null)
+    const req = new NextRequest('http://test.com/api/segments')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('creates a segment', async () => {
+    vi.mocked(getSessionOrg).mockResolvedValue('org1')
+    const body = { name: 'Test', dslJson: {} }
+    const req = new NextRequest('http://test.com/api/segments', {
+      method: 'POST',
+      body: JSON.stringify(body),
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.segment.name).toBe('Test')
+    expect(db.segments.size).toBe(1)
+  })
+})

--- a/src/tests/components/autosave.test.tsx
+++ b/src/tests/components/autosave.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { SegmentEditorSheet, SegmentDraft } from '@/components/segments/SegmentEditorSheet'
+
+vi.useFakeTimers()
+
+describe('SegmentEditorSheet autosave', () => {
+  it('debounces changes', async () => {
+    const draft: SegmentDraft = {
+      id: '1',
+      name: '',
+      subtitle: '',
+      category: '',
+      filtersMode: 'any',
+      filters: [],
+    }
+    const onChange = vi.fn()
+    render(
+      <SegmentEditorSheet
+        open
+        segment={draft}
+        onClose={() => {}}
+        onChange={onChange}
+      />
+    )
+
+    const input = document.querySelector('input[placeholder="Title"]') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'A' } })
+    fireEvent.change(input, { target: { value: 'AB' } })
+    fireEvent.change(input, { target: { value: 'ABC' } })
+
+    vi.runAllTimers()
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange.mock.calls[0][0].name).toBe('ABC')
+  })
+})

--- a/src/tests/components/breadcrumb-portal.test.tsx
+++ b/src/tests/components/breadcrumb-portal.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { BreadcrumbPortal } from '@/components/shared/BreadcrumbPortal'
+
+describe('BreadcrumbPortal', () => {
+  it('renders children into portal', async () => {
+    render(
+      <BreadcrumbPortal>
+        <span>Home</span>
+      </BreadcrumbPortal>
+    )
+    const portal = await screen.findByText('Home')
+    expect(portal).toBeInTheDocument()
+    const container = document.getElementById('breadcrumb-portal')
+    expect(container).not.toBeNull()
+    expect(container?.textContent).toContain('Home')
+  })
+})

--- a/src/tests/components/filter-builder.test.tsx
+++ b/src/tests/components/filter-builder.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { SegmentFiltersBuilder, SegmentFilter } from '@/components/segments/SegmentFiltersBuilder'
+
+describe('SegmentFiltersBuilder', () => {
+  it('serializes builder state', async () => {
+    const user = userEvent.setup()
+    let value = { mode: 'any' as const, filters: [] as SegmentFilter[] }
+    render(
+      <SegmentFiltersBuilder
+        value={value}
+        onChange={(v) => {
+          value = v
+        }}
+      />
+    )
+
+    await user.click(screen.getByText('Add filter'))
+    const input = screen.getByPlaceholderText('Value')
+    await user.type(input, 'VIP')
+
+    const trigger = screen.getByRole('combobox') // mode select
+    await user.click(trigger)
+    await user.click(screen.getByText('All'))
+
+    expect(() => JSON.stringify(value)).not.toThrow()
+    expect(value.mode).toBe('all')
+    expect(value.filters[0]).toMatchObject({ type: 'tag', value: 'VIP' })
+  })
+})

--- a/src/tests/lib/__snapshots__/renderBlocksToHtml.test.ts.snap
+++ b/src/tests/lib/__snapshots__/renderBlocksToHtml.test.ts.snap
@@ -1,0 +1,4 @@
+exports[`renderBlocksToHtml renders blocks to html snapshot 1`] = `
+<h1>Hello &lt;World&gt;</h1>
+<p>Paragraph &amp; more</p>
+`

--- a/src/tests/lib/renderBlocksToHtml.test.ts
+++ b/src/tests/lib/renderBlocksToHtml.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest'
+import { renderBlocksToHtml, EmailBlock } from '@/lib/email/render'
+
+describe('renderBlocksToHtml', () => {
+  it('renders blocks to html snapshot', () => {
+    const blocks: EmailBlock[] = [
+      { id: '1', type: 'heading', content: 'Hello <World>' },
+      { id: '2', type: 'paragraph', content: 'Paragraph & more' },
+    ]
+    const html = renderBlocksToHtml(blocks)
+    expect(html).toMatchSnapshot()
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary
- setup Vitest with jsdom and testing-library
- add API tests for segments, members, and campaign scheduling
- add UI tests including autosave debounce, breadcrumb portal, filter builder serialization, and snapshot for block rendering

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74d4a1190832d91f84ae9097618ed