### PR TITLE
refactor: remove swr usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
-    "zod": "^4.0.17",
-    "swr": "^2.2.0"
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- replace useSWR-based logic with manual fetch in useAutosave hook
- drop unused swr dependency

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a759c9cc98832db090b79365d15575