### PR TITLE
fix: prevent autosave loop

### DIFF
--- a/src/hooks/use-autosave.ts
+++ b/src/hooks/use-autosave.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { fetcher, postJson } from '@/lib/fetch'
 
 interface AutosaveResponse<T> {
@@ -26,9 +26,14 @@ export function useAutosave<T>({ key, initialData, onSave }: UseAutosaveOptions<
   const [draft, setDraft] = useState<T>(initialData)
   const [saving, setSaving] = useState(false)
   const [savedAt, setSavedAt] = useState<Date | null>(null)
+  const previousInitialData = useRef<T>(initialData)
 
   useEffect(() => {
-    setDraft(initialData)
+    const serialized = JSON.stringify(initialData)
+    if (JSON.stringify(previousInitialData.current) !== serialized) {
+      setDraft(initialData)
+    }
+    previousInitialData.current = initialData
   }, [initialData])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid infinite state loop in `useAutosave` when `initialData` doesn't actually change

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a75c0b6110832d879f768bb3ce0881