### PR TITLE
feat: add marketing dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-resizable-panels": "^3.0.4",
     "recharts": "^2.15.4",
     "sonner": "^2.0.7",
+    "swr": "^2.2.2",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
     "zod": "^4.0.17"

--- a/src/app/marketing/page.tsx
+++ b/src/app/marketing/page.tsx
@@ -1,11 +1,13 @@
 import { SidebarInset } from "@/components/ui/sidebar"
 import { SiteHeader } from "@/components/site-header"
+import { Dashboard } from "@/components/marketing/Dashboard"
 
 export default function MarketingPage() {
   return (
     <SidebarInset>
       <SiteHeader title="Marketing" />
       <div className="p-4">
+        <Dashboard />
       </div>
     </SidebarInset>
   )

--- a/src/components/marketing/Dashboard.tsx
+++ b/src/components/marketing/Dashboard.tsx
@@ -1,0 +1,141 @@
+'use client'
+
+import useSWR from 'swr'
+import Link from 'next/link'
+import { fetcher } from '@/lib/fetch'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+interface Campaign {
+  id: string
+  name: string
+  status: string
+  createdAt: string
+}
+
+interface Template {
+  id: string
+  name: string
+  description?: string
+}
+
+interface CampaignListResponse {
+  campaigns: Campaign[]
+}
+
+interface TemplateListResponse {
+  templates: Template[]
+}
+
+export function Dashboard() {
+  const { data: campaignData } = useSWR<CampaignListResponse>(
+    '/api/campaigns',
+    fetcher
+  )
+  const { data: templateData } = useSWR<TemplateListResponse>(
+    '/api/templates',
+    fetcher
+  )
+
+  const campaigns = campaignData?.campaigns ?? []
+  const templates = templateData?.templates ?? []
+
+  const total = campaigns.length
+  const scheduled = campaigns.filter((c) => c.status === 'SCHEDULED').length
+  const sent = campaigns.filter((c) => c.status === 'SENT').length
+
+  if (campaignData && campaigns.length === 0) {
+    return (
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card data-empty>
+          <CardContent className="flex flex-col items-center justify-center gap-4 p-6 text-center">
+            <p className="text-sm text-muted-foreground">
+              You haven't created any campaigns yet
+            </p>
+            <Button asChild>
+              <Link href="/marketing/campaigns/new">Create campaign</Link>
+            </Button>
+          </CardContent>
+        </Card>
+        <Card data-empty>
+          <CardContent className="flex flex-col items-center justify-center gap-4 p-6 text-center">
+            <p className="text-sm text-muted-foreground">
+              Need inspiration? Start from a template
+            </p>
+            <Button asChild>
+              <Link href="/marketing/templates">Browse templates</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Total</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{total}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Scheduled</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{scheduled}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">Sent</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{sent}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <section>
+        <h2 className="mb-4 text-lg font-semibold">Recent campaigns</h2>
+        <div className="grid gap-4">
+          {campaigns.slice(0, 5).map((c) => (
+            <Card key={c.id}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base font-medium">{c.name}</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-muted-foreground capitalize">
+                {c.status.toLowerCase()}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-lg font-semibold">Templates</h2>
+        <div className="grid gap-4 sm:grid-cols-3">
+          {templates.slice(0, 3).map((t) => (
+            <Card key={t.id}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-base font-medium">{t.name}</CardTitle>
+              </CardHeader>
+              {t.description && (
+                <CardContent className="text-sm text-muted-foreground">
+                  {t.description}
+                </CardContent>
+              )}
+            </Card>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default Dashboard
+


### PR DESCRIPTION
## Summary
- add marketing Dashboard component to load stats, recent campaigns, and templates via SWR
- show empty-state calls to action when campaigns list is empty
- render Dashboard on marketing page and add swr dependency

## Testing
- `npm test` *(fails: vitest not found, dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a76401805c832d98c7d5369218fda4