### PR TITLE
feat: add marketing campaign composer and pages

### DIFF
--- a/src/app/marketing/campaigns/[id]/page.tsx
+++ b/src/app/marketing/campaigns/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { CampaignComposer } from "@/components/marketing/CampaignComposer"
+
+export default function CampaignPage({ params }: { params: { id: string } }) {
+  return (
+    <SidebarInset>
+      <SiteHeader title="Campaign" />
+      <div className="p-4">
+        <CampaignComposer campaignId={params.id} />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/app/marketing/campaigns/data.ts
+++ b/src/app/marketing/campaigns/data.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+export const campaignSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(["DRAFT", "SCHEDULED", "SENDING", "SENT"]),
+  recipients: z.string(),
+  updatedAt: z.string(),
+})
+
+export type Campaign = z.infer<typeof campaignSchema>
+
+export const campaigns: Campaign[] = [
+  {
+    id: "1",
+    name: "Welcome Series",
+    status: "DRAFT",
+    recipients: "120 contacts",
+    updatedAt: "2024-05-01",
+  },
+  {
+    id: "2",
+    name: "Spring Fundraiser",
+    status: "SENT",
+    recipients: "250 contacts",
+    updatedAt: "2024-04-15",
+  },
+]

--- a/src/app/marketing/campaigns/new/page.tsx
+++ b/src/app/marketing/campaigns/new/page.tsx
@@ -1,0 +1,17 @@
+import { randomUUID } from "crypto"
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { CampaignComposer } from "@/components/marketing/CampaignComposer"
+
+export default function NewCampaignPage() {
+  const id = randomUUID()
+
+  return (
+    <SidebarInset>
+      <SiteHeader title="New Campaign" />
+      <div className="p-4">
+        <CampaignComposer campaignId={id} />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/app/marketing/campaigns/page.tsx
+++ b/src/app/marketing/campaigns/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link"
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+
+import { campaigns } from "./data"
+
+export default function CampaignsPage() {
+  return (
+    <SidebarInset>
+      <SiteHeader title="Campaigns" />
+      <div className="p-4 space-y-4">
+        <div>
+          <Button asChild>
+            <Link href="/marketing/campaigns/new">New Campaign</Link>
+          </Button>
+        </div>
+        <table className="w-full text-sm">
+          <thead className="text-left">
+            <tr>
+              <th className="p-2">Name</th>
+              <th className="p-2">Status</th>
+              <th className="p-2">Recipients</th>
+              <th className="p-2">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {campaigns.map((c) => (
+              <tr key={c.id} className="border-t">
+                <td className="p-2">
+                  <Link href={`/marketing/campaigns/${c.id}`}>{c.name}</Link>
+                </td>
+                <td className="p-2">
+                  <Badge variant="outline">{c.status}</Badge>
+                </td>
+                <td className="p-2">{c.recipients}</td>
+                <td className="p-2">{c.updatedAt}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/components/marketing/CampaignComposer.tsx
+++ b/src/components/marketing/CampaignComposer.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useState } from "react"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb"
+import { BreadcrumbPortal } from "@/components/shared/BreadcrumbPortal"
+import { useAutosave } from "@/hooks/use-autosave"
+
+interface Draft {
+  subject: string
+  content: string
+  recipients: string[]
+  sendAt: string
+}
+
+interface CampaignComposerProps {
+  campaignId: string
+}
+
+function AutosaveBadge({
+  saving,
+  savedAt,
+}: {
+  saving: boolean
+  savedAt: Date | null
+}) {
+  return (
+    <Badge variant="outline">
+      {saving ? "Saving..." : savedAt ? `Saved ${savedAt.toLocaleTimeString()}` : "Saved"}
+    </Badge>
+  )
+}
+
+function RecipientsTable({
+  recipients,
+  onChange,
+}: {
+  recipients: string[]
+  onChange: (recipients: string[]) => void
+}) {
+  const [value, setValue] = useState("")
+  return (
+    <div className="space-y-2">
+      <div className="font-medium">Recipients</div>
+      <table className="w-full text-sm">
+        <tbody>
+          {recipients.map((r) => (
+            <tr key={r} className="border-t">
+              <td className="p-1">{r}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex gap-2">
+        <Input
+          value={value}
+          placeholder="email@example.com"
+          onChange={(e) => setValue(e.target.value)}
+        />
+        <Button
+          type="button"
+          onClick={() => {
+            const v = value.trim()
+            if (v) {
+              onChange([...recipients, v])
+              setValue("")
+            }
+          }}
+        >
+          Add
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function CampaignComposer({ campaignId }: CampaignComposerProps) {
+  const { draft, setDraft, saving, savedAt } = useAutosave<Draft>({
+    key: campaignId ? `campaign-${campaignId}` : undefined,
+    initialData: { subject: "", content: "", recipients: [], sendAt: "" },
+  })
+
+  return (
+    <div className="space-y-6">
+      <BreadcrumbPortal>
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/marketing">Marketing</BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>
+                {draft.subject || "New Campaign"}
+              </BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+      </BreadcrumbPortal>
+
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">{draft.subject || "Untitled Campaign"}</h1>
+        <AutosaveBadge saving={saving} savedAt={savedAt} />
+      </div>
+
+      <Input
+        placeholder="Subject"
+        value={draft.subject}
+        onChange={(e) => setDraft({ ...draft, subject: e.target.value })}
+      />
+      <Textarea
+        placeholder="Write your email..."
+        className="h-60"
+        value={draft.content}
+        onChange={(e) => setDraft({ ...draft, content: e.target.value })}
+      />
+
+      <RecipientsTable
+        recipients={draft.recipients}
+        onChange={(r) => setDraft({ ...draft, recipients: r })}
+      />
+
+      <div className="space-y-2">
+        <Input
+          type="datetime-local"
+          value={draft.sendAt}
+          onChange={(e) => setDraft({ ...draft, sendAt: e.target.value })}
+        />
+        <Button type="button">Schedule</Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- list marketing campaigns with status, recipients, and update info
- add campaign composer page for new and existing campaigns
- implement campaign composer with editor, recipients table, scheduling, breadcrumbs, and autosave badge

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68a764027314832da11f154ef8d66a36