### PR TITLE
feat: add marketing template pages and editor

### DIFF
--- a/src/app/marketing/templates/[id]/page.tsx
+++ b/src/app/marketing/templates/[id]/page.tsx
@@ -1,0 +1,18 @@
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { TemplateEditor } from "@/components/marketing/TemplateEditor"
+
+interface TemplatePageProps {
+  params: { id: string }
+}
+
+export default function TemplatePage({ params }: TemplatePageProps) {
+  return (
+    <SidebarInset>
+      <SiteHeader title="Edit Template" />
+      <div className="p-4">
+        <TemplateEditor templateId={params.id} />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/app/marketing/templates/new/page.tsx
+++ b/src/app/marketing/templates/new/page.tsx
@@ -1,0 +1,14 @@
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { TemplateEditor } from "@/components/marketing/TemplateEditor"
+
+export default function NewTemplatePage() {
+  return (
+    <SidebarInset>
+      <SiteHeader title="New Template" />
+      <div className="p-4">
+        <TemplateEditor />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/app/marketing/templates/page.tsx
+++ b/src/app/marketing/templates/page.tsx
@@ -1,0 +1,14 @@
+import { SidebarInset } from "@/components/ui/sidebar"
+import { SiteHeader } from "@/components/site-header"
+import { TemplateGrid } from "@/components/marketing/TemplateGrid"
+
+export default function TemplatesPage() {
+  return (
+    <SidebarInset>
+      <SiteHeader title="Templates" />
+      <div className="p-4">
+        <TemplateGrid />
+      </div>
+    </SidebarInset>
+  )
+}

--- a/src/components/campaigns/CampaignComposer.tsx
+++ b/src/components/campaigns/CampaignComposer.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
+import { useSearchParams } from "next/navigation"
 
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -8,6 +9,7 @@ import { EmailBlock, renderEmail } from "@/lib/email/render"
 
 import { HeadingBlock } from "./Blocks/HeadingBlock"
 import { ParagraphBlock } from "./Blocks/ParagraphBlock"
+import { templates } from "@/components/marketing/templates"
 
 interface CampaignComposerProps {
   campaignId: string
@@ -15,13 +17,14 @@ interface CampaignComposerProps {
 
 export function CampaignComposer({ campaignId }: CampaignComposerProps) {
   const storageKey = `campaign-${campaignId}`
+  const searchParams = useSearchParams()
 
   const [title, setTitle] = useState("")
   const [blocks, setBlocks] = useState<EmailBlock[]>([])
   const [status, setStatus] = useState<"DRAFT" | "SCHEDULED">("DRAFT")
   const [scheduledAt, setScheduledAt] = useState("")
 
-  // load draft
+  // load draft or template
   useEffect(() => {
     if (typeof window === "undefined") return
     const saved = localStorage.getItem(storageKey)
@@ -32,9 +35,19 @@ export function CampaignComposer({ campaignId }: CampaignComposerProps) {
         setBlocks(data.blocks || [])
         setStatus(data.status || "DRAFT")
         setScheduledAt(data.scheduledAt || "")
+        return
       } catch {}
     }
-  }, [storageKey])
+
+    const templateId = searchParams.get("template")
+    if (templateId) {
+      const template = templates.find((t) => t.id === templateId)
+      if (template) {
+        setTitle(template.name)
+        setBlocks(template.blocks)
+      }
+    }
+  }, [storageKey, searchParams])
 
   // autosave
   useEffect(() => {

--- a/src/components/marketing/TemplateEditor.tsx
+++ b/src/components/marketing/TemplateEditor.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+const MailyEditor = dynamic(
+  () => import("maily").then((mod: any) => mod.Editor),
+  { ssr: false, loading: () => <div>Loading editor...</div> }
+)
+
+interface TemplateEditorProps {
+  templateId?: string
+}
+
+export function TemplateEditor({ templateId }: TemplateEditorProps) {
+  return (
+    <div className="rounded border p-2">
+      <MailyEditor key={templateId} />
+    </div>
+  )
+}

--- a/src/components/marketing/TemplateGrid.tsx
+++ b/src/components/marketing/TemplateGrid.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import { useRouter } from "next/navigation"
+
+import { templates } from "./templates"
+
+export function TemplateGrid() {
+  const router = useRouter()
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {templates.map((template) => (
+        <div key={template.id} className="space-y-2 rounded border p-4">
+          <div
+            className="aspect-video w-full overflow-hidden rounded border bg-background"
+            dangerouslySetInnerHTML={{ __html: template.preview }}
+          />
+          <div className="flex items-center justify-between">
+            <div className="font-medium">{template.name}</div>
+            <Button
+              size="sm"
+              onClick={() =>
+                router.push(`/contacts/campaigns/new?template=${template.id}`)
+              }
+            >
+              Use template
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/marketing/templates.ts
+++ b/src/components/marketing/templates.ts
@@ -1,0 +1,42 @@
+import type { EmailBlock } from "@/lib/email/render"
+import { renderEmail } from "@/lib/email/render"
+
+export interface EmailTemplate {
+  id: string
+  name: string
+  preview: string
+  blocks: EmailBlock[]
+}
+
+const welcomeBlocks: EmailBlock[] = [
+  { id: "welcome-heading", type: "heading", content: "Welcome!" },
+  {
+    id: "welcome-paragraph",
+    type: "paragraph",
+    content: "Thanks for joining our newsletter.",
+  },
+]
+
+const saleBlocks: EmailBlock[] = [
+  { id: "sale-heading", type: "heading", content: "Big Sale" },
+  {
+    id: "sale-paragraph",
+    type: "paragraph",
+    content: "Don't miss out on our latest offers.",
+  },
+]
+
+export const templates: EmailTemplate[] = [
+  {
+    id: "welcome",
+    name: "Welcome Template",
+    blocks: welcomeBlocks,
+    preview: renderEmail(welcomeBlocks),
+  },
+  {
+    id: "sale",
+    name: "Sale Template",
+    blocks: saleBlocks,
+    preview: renderEmail(saleBlocks),
+  },
+]

--- a/src/types/maily.d.ts
+++ b/src/types/maily.d.ts
@@ -1,0 +1,3 @@
+declare module "maily" {
+  export const Editor: any
+}


### PR DESCRIPTION
## Summary
- add marketing template grid and editor pages
- implement TemplateGrid and TemplateEditor components
- allow campaign composer to preload from template selection

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a76403756c832d85062fef5bdd5110