### PR TITLE
Remove SWR from marketing dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "react-resizable-panels": "^3.0.4",
     "recharts": "^2.15.4",
     "sonner": "^2.0.7",
-    "swr": "^2.2.2",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
     "zod": "^4.0.17"


### PR DESCRIPTION
## Summary
- refactor marketing dashboard to use manual fetch logic instead of `swr`
- drop unused `swr` dependency

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7728eb1a4832d912aa9a5d9fc7aa5