### PR TITLE
feat: embed maily.to editor and center campaign composer

### DIFF
--- a/src/app/marketing/campaigns/new/page.tsx
+++ b/src/app/marketing/campaigns/new/page.tsx
@@ -9,8 +9,10 @@ export default function NewCampaignPage() {
   return (
     <SidebarInset>
       <SiteHeader title="New Campaign" />
-      <div className="p-4">
-        <CampaignComposer campaignId={id} />
+      <div className="flex flex-1 items-center justify-center p-4">
+        <div className="w-full max-w-5xl rounded-lg border bg-background p-4 shadow">
+          <CampaignComposer campaignId={id} />
+        </div>
       </div>
     </SidebarInset>
   )

--- a/src/components/marketing/CampaignComposer.tsx
+++ b/src/components/marketing/CampaignComposer.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react"
 import { Input } from "@/components/ui/input"
-import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import {
@@ -15,6 +14,7 @@ import {
 } from "@/components/ui/breadcrumb"
 import { BreadcrumbPortal } from "@/components/shared/BreadcrumbPortal"
 import { useAutosave } from "@/hooks/use-autosave"
+import { MailyEditor } from "./MailyEditor"
 
 interface Draft {
   subject: string
@@ -118,12 +118,8 @@ export function CampaignComposer({ campaignId }: CampaignComposerProps) {
         value={draft.subject}
         onChange={(e) => setDraft({ ...draft, subject: e.target.value })}
       />
-      <Textarea
-        placeholder="Write your email..."
-        className="h-60"
-        value={draft.content}
-        onChange={(e) => setDraft({ ...draft, content: e.target.value })}
-      />
+
+      <MailyEditor />
 
       <RecipientsTable
         recipients={draft.recipients}

--- a/src/components/marketing/MailyEditor.tsx
+++ b/src/components/marketing/MailyEditor.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+export function MailyEditor() {
+  return (
+    <iframe
+      src="https://maily.to/playground"
+      className="h-[600px] w-full rounded-md border"
+      title="Email Composer"
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- embed maily.to playground as iframe email editor
- center campaign composer in rounded container

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)
- `npm test` (fails: vitest: not found)
- `npm run lint` (fails: next: not found)


------
https://chatgpt.com/codex/tasks/task_e_68a78679fb08832daa2eb1091052b775