### PR TITLE
feat: add email composer with tiptap editor

### DIFF
--- a/src/app/marketing/_components/EmailComposer.tsx
+++ b/src/app/marketing/_components/EmailComposer.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import { useState, useCallback, useEffect } from "react"
+import { Editor as TiptapEditor, EditorContent } from "@tiptap/react"
+import StarterKit from "@tiptap/starter-kit"
+import VariableExtension from "tiptap-extension-variable"
+import ImageUploadExtension from "tiptap-extension-image-upload"
+
+export function EmailComposer() {
+  const [editor] = useState(() =>
+    new TiptapEditor({
+      extensions: [StarterKit, VariableExtension, ImageUploadExtension],
+      content: "",
+    }),
+  )
+
+  const handleUpdate = useCallback(() => {
+    // handle editor updates
+  }, [editor])
+
+  useEffect(() => {
+    editor.on("update", handleUpdate)
+    return () => {
+      editor.off("update", handleUpdate)
+    }
+  }, [editor, handleUpdate])
+
+  return (
+    <div className="rounded-2xl border bg-background p-4">
+      <EditorContent editor={editor} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add marketing EmailComposer component built with TipTap

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78cfe5f4c832d806d95f52cea1541