### PR TITLE
feat: render email templates

### DIFF
--- a/src/app/api/email/render/route.ts
+++ b/src/app/api/email/render/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Maily } from "@maily-to/render";
+
+export async function POST(req: NextRequest) {
+  const { json, variables = {}, payload = {} } = await req.json();
+
+  const m = new Maily(json);
+
+  for (const [key, value] of Object.entries(variables)) {
+    m.setVariableValue(key, value as any);
+  }
+
+  for (const [key, value] of Object.entries(payload)) {
+    m.setPayloadValue(key, value as any);
+  }
+
+  const html = await m.render();
+
+  return NextResponse.json({ html });
+}
+


### PR DESCRIPTION
## Summary
- add API endpoint to render email templates via Maily

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78d00c764832da17e80edfc5c7c75