### PR TITLE
feat: add email tables and template autosave

### DIFF
--- a/packages/db/prisma/migrations/0003_add_email_tables/migration.sql
+++ b/packages/db/prisma/migrations/0003_add_email_tables/migration.sql
@@ -1,0 +1,55 @@
+-- CreateTable
+CREATE TABLE "EmailTemplate" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "contentJson" JSONB NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "EmailTemplate_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "EmailTemplateSnapshot" (
+    "id" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "html" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "EmailTemplateSnapshot_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "EmailTemplateSnapshot_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "EmailTemplate"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "EmailCampaign" (
+    "id" TEXT NOT NULL,
+    "templateId" TEXT NOT NULL,
+    "subject" TEXT NOT NULL,
+    "fromName" TEXT NOT NULL,
+    "fromEmail" TEXT NOT NULL,
+    "segmentId" TEXT,
+    "status" TEXT NOT NULL,
+    "scheduledAt" TIMESTAMP(3),
+    CONSTRAINT "EmailCampaign_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "EmailCampaign_templateId_fkey" FOREIGN KEY ("templateId") REFERENCES "EmailTemplate"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "EmailMessage" (
+    "id" TEXT NOT NULL,
+    "campaignId" TEXT NOT NULL,
+    "recipient" TEXT NOT NULL,
+    "variables" JSONB NOT NULL,
+    "status" TEXT NOT NULL,
+    "sentAt" TIMESTAMP(3),
+    CONSTRAINT "EmailMessage_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "EmailMessage_campaignId_fkey" FOREIGN KEY ("campaignId") REFERENCES "EmailCampaign"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+-- CreateTable
+CREATE TABLE "EmailAsset" (
+    "id" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "width" INTEGER NOT NULL,
+    "height" INTEGER NOT NULL,
+    "createdBy" TEXT NOT NULL,
+    CONSTRAINT "EmailAsset_pkey" PRIMARY KEY ("id")
+);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -51,3 +51,52 @@ model Contact {
   email     String   @unique
   createdAt DateTime @default(now())
 }
+
+model EmailTemplate {
+  id          String                   @id @default(uuid())
+  name        String
+  contentJson Json
+  createdBy   String
+  updatedAt   DateTime                @updatedAt
+  snapshots   EmailTemplateSnapshot[]
+  campaigns   EmailCampaign[]
+}
+
+model EmailTemplateSnapshot {
+  id         String        @id @default(uuid())
+  template   EmailTemplate @relation(fields: [templateId], references: [id])
+  templateId String
+  html       String
+  createdAt  DateTime      @default(now())
+}
+
+model EmailCampaign {
+  id          String        @id @default(uuid())
+  template    EmailTemplate @relation(fields: [templateId], references: [id])
+  templateId  String
+  subject     String
+  fromName    String
+  fromEmail   String
+  segmentId   String?
+  status      String
+  scheduledAt DateTime?
+  messages    EmailMessage[]
+}
+
+model EmailMessage {
+  id         String        @id @default(uuid())
+  campaign   EmailCampaign @relation(fields: [campaignId], references: [id])
+  campaignId String
+  recipient  String
+  variables  Json
+  status     String
+  sentAt     DateTime?
+}
+
+model EmailAsset {
+  id        String @id @default(uuid())
+  url       String
+  width     Int
+  height    Int
+  createdBy String
+}

--- a/src/app/api/templates/[id]/content/route.ts
+++ b/src/app/api/templates/[id]/content/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { prisma } from '@/lib/prisma'
+
+const saveSchema = z.object({
+  contentJson: z.any(),
+  html: z.string(),
+})
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const body = await req.json().catch(() => null)
+  const parsed = saveSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 422 }
+    )
+  }
+
+  const { contentJson, html } = parsed.data
+  const templateId = params.id
+
+  await prisma.emailTemplate.update({
+    where: { id: templateId },
+    data: { contentJson },
+  })
+
+  await prisma.emailTemplateSnapshot.create({
+    data: { templateId, html },
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/components/marketing/TemplateEditor.tsx
+++ b/src/components/marketing/TemplateEditor.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import { useRef } from "react"
 import dynamic from "next/dynamic"
+import { renderEmail } from "@/lib/email/render"
 
 const MailyEditor = dynamic(
   () => import("maily").then((mod: any) => mod.Editor),
@@ -12,9 +14,26 @@ interface TemplateEditorProps {
 }
 
 export function TemplateEditor({ templateId }: TemplateEditorProps) {
+  const timeoutRef = useRef<NodeJS.Timeout>()
+
+  const persist = async (json: any) => {
+    if (!templateId) return
+    const html = renderEmail((json?.blocks as any[]) || [])
+    await fetch(`/api/templates/${templateId}/content`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contentJson: json, html }),
+    })
+  }
+
+  const handleChange = (json: any) => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => persist(json), 500)
+  }
+
   return (
     <div className="rounded border p-2">
-      <MailyEditor key={templateId} />
+      <MailyEditor key={templateId} onChange={handleChange} />
     </div>
   )
 }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,13 @@
+import { PrismaClient } from '@prisma/client'
+
+const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({ log: ['error', 'warn'] })
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma
+}
+
+export default prisma


### PR DESCRIPTION
## Summary
- add Prisma models and migration for email templates, campaigns, messages, assets
- autosave template content with debounced editor updates
- snapshot rendered HTML for audit storage

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78d0231ec832d91f36f5477f44c9a