### PR TITLE
feat(email): integrate nodemailer and enforce unsubscribe links

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
-    "zod": "^4.0.17"
+    "zod": "^4.0.17",
+    "nodemailer": "^6.9.13"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/packages/emailer/README.md
+++ b/src/packages/emailer/README.md
@@ -1,6 +1,30 @@
 # Emailer Package
 
-Email templating utilities placeholder.
+Email templating utilities built around a simple queue. Messages are rendered
+per recipient on the server using the block based templating utilities in
+`@/lib/email/render` and are sent via [Nodemailer](https://nodemailer.com/).
 
-Provides a minimal queue interface that currently logs payloads and includes a
-placeholder for metrics collection.
+### Usage
+
+```ts
+import { enqueueEmail } from "@/packages/emailer";
+
+await enqueueEmail({
+  to: "user@example.com",
+  subject: "Hello",
+  blocks: [{ id: "greeting", type: "paragraph", content: "Hi {{name}}" }],
+  variables: {
+    name: "Ada",
+    unsubscribe_url: "https://example.com/unsub",
+  },
+});
+```
+
+The `unsubscribe_url` variable is required and the rendered HTML must contain
+its value; otherwise an error is thrown.
+
+The queue currently sends immediately using Nodemailer's transport. If no
+`SMTP_URL` environment variable is provided, a JSON transport is used for
+development/testing.
+
+Metrics collection hooks remain TODO.

--- a/src/packages/emailer/queue.ts
+++ b/src/packages/emailer/queue.ts
@@ -1,10 +1,56 @@
+import nodemailer from "nodemailer";
+import { renderEmail, type EmailBlock } from "@/lib/email/render";
+
 export interface QueuePayload {
   to: string;
   subject: string;
-  html: string;
+  /**
+   * Email content represented as blocks that will be rendered on the server
+   * for each recipient. Variables in the rendered HTML are of the form
+   * `{{variable_name}}` and will be replaced using the values provided in
+   * `variables`.
+   */
+  blocks: EmailBlock[];
+  /**
+   * Per-recipient variables used when rendering the email. An
+   * `unsubscribe_url` value is required and will be enforced before sending.
+   */
+  variables: Record<string, string>;
+}
+
+function renderWithVariables(
+  blocks: EmailBlock[],
+  variables: Record<string, string>
+): string {
+  let html = renderEmail(blocks);
+  for (const [key, value] of Object.entries(variables)) {
+    const pattern = new RegExp(`{{\s*${key}\s*}}`, "g");
+    html = html.replace(pattern, value);
+  }
+  return html;
 }
 
 export async function enqueueEmail(payload: QueuePayload): Promise<void> {
-  console.log("Enqueue email", payload);
+  const { to, subject, blocks, variables } = payload;
+  if (!variables.unsubscribe_url) {
+    throw new Error("unsubscribe_url is required");
+  }
+  const html = renderWithVariables(blocks, variables);
+  if (!html.includes(variables.unsubscribe_url)) {
+    throw new Error("Rendered HTML must include unsubscribe_url");
+  }
+
+  const transporter = nodemailer.createTransport(
+    process.env.SMTP_URL ? process.env.SMTP_URL : { jsonTransport: true }
+  );
+
+  await transporter.sendMail({
+    from: process.env.EMAIL_FROM || "no-reply@example.com",
+    to,
+    subject,
+    html,
+  });
+
+  console.log("Enqueue email", { to, subject });
   // TODO: record metrics
 }

--- a/src/tests/emailer/enqueueEmail.test.ts
+++ b/src/tests/emailer/enqueueEmail.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { enqueueEmail } from "@/packages/emailer";
+import type { EmailBlock } from "@/lib/email/render";
+
+const blocks: EmailBlock[] = [
+  {
+    id: "greeting",
+    type: "paragraph",
+    content: "Hello {{name}} <a href=\"{{unsubscribe_url}}\">Unsub</a>",
+  },
+];
+
+describe("enqueueEmail", () => {
+  it("throws when unsubscribe_url missing", async () => {
+    await expect(
+      enqueueEmail({
+        to: "test@example.com",
+        subject: "Test",
+        blocks,
+        variables: { name: "Ada" },
+      })
+    ).rejects.toThrow("unsubscribe_url");
+  });
+
+  it("sends when unsubscribe_url present", async () => {
+    await enqueueEmail({
+      to: "test@example.com",
+      subject: "Test",
+      blocks,
+      variables: {
+        name: "Ada",
+        unsubscribe_url: "https://example.com/unsub",
+      },
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- render email blocks per recipient and send via Nodemailer
- require `unsubscribe_url` variable in rendered HTML
- document email queue usage and add tests for unsubscribe enforcement

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78d060140832d83989c34946c24d9