### PR TITLE
feat: add email image upload route

### DIFF
--- a/src/app/api/uploads/email-image/route.ts
+++ b/src/app/api/uploads/email-image/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { randomUUID } from "crypto";
+import { getSessionOrg } from "@/lib/auth";
+
+export async function POST(req: NextRequest) {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const formData = await req.formData();
+  const file = formData.get("file");
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const ext = file.name.split(".").pop();
+  const key = `${orgId}/${randomUUID()}${ext ? `.${ext}` : ""}`;
+
+  const supabase = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+  const bucket = process.env.SUPABASE_STORAGE_BUCKET || "uploads";
+
+  const { error } = await supabase.storage
+    .from(bucket)
+    .upload(key, buffer, {
+      contentType: file.type,
+    });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const { data } = supabase.storage.from(bucket).getPublicUrl(key);
+
+  return NextResponse.json({ url: data.publicUrl });
+}


### PR DESCRIPTION
## Summary
- add API endpoint to upload email images to Supabase Storage
- return public URL for inserted images

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a78d0741a0832d9591fd758a0250fd