### PR TITLE
feat: centralize API auth and error handling

### DIFF
--- a/src/app/api/autosave/route.ts
+++ b/src/app/api/autosave/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { getSessionOrg } from "@/lib/auth";
+import { requireOrg, jsonError } from "@/lib/api";
 import { db } from "@/lib/store";
 
 const saveSchema = z.object({
@@ -9,35 +9,28 @@ const saveSchema = z.object({
 });
 
 export async function GET(req: NextRequest) {
-  const orgId = await getSessionOrg();
-  if (!orgId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const orgId = await requireOrg(req);
+  if (orgId instanceof NextResponse) return orgId;
   const { searchParams } = new URL(req.url);
   const key = searchParams.get("key");
   if (!key) {
-    return NextResponse.json({ error: "Missing key" }, { status: 422 });
+    return jsonError(422, "Missing key");
   }
   const orgStore = db.autosave.get(orgId);
   const entry = orgStore?.get(key);
   if (!entry) {
-    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+    return jsonError(404, "Not Found");
   }
   return NextResponse.json(entry);
 }
 
 export async function POST(req: NextRequest) {
-  const orgId = await getSessionOrg();
-  if (!orgId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const orgId = await requireOrg(req);
+  if (orgId instanceof NextResponse) return orgId;
   const body = await req.json().catch(() => null);
   const parsed = saveSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten() },
-      { status: 422 }
-    );
+    return jsonError(422, parsed.error.flatten());
   }
   let orgStore = db.autosave.get(orgId);
   if (!orgStore) {

--- a/src/app/api/campaigns/route.ts
+++ b/src/app/api/campaigns/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { randomUUID } from "crypto";
-import { getSessionOrg } from "@/lib/auth";
+import { requireOrg, jsonError } from "@/lib/api";
 import { db, Campaign, CampaignStatus } from "@/lib/store";
 
 const PAGE_SIZE = 10;
@@ -14,10 +14,8 @@ const createSchema = z.object({
 });
 
 export async function GET(req: NextRequest) {
-  const orgId = await getSessionOrg();
-  if (!orgId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const orgId = await requireOrg(req);
+  if (orgId instanceof NextResponse) return orgId;
   const { searchParams } = new URL(req.url);
   const cursor = searchParams.get("cursor") || undefined;
   const campaigns = Array.from(db.campaigns.values()).filter(
@@ -32,26 +30,21 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const orgId = await getSessionOrg();
-  if (!orgId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const orgId = await requireOrg(req);
+  if (orgId instanceof NextResponse) return orgId;
   const body = await req.json().catch(() => null);
   const parsed = createSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten() },
-      { status: 422 }
-    );
+    return jsonError(422, parsed.error.flatten());
   }
   const { name, contentJson, segmentId, sendAt } = parsed.data;
   if (segmentId) {
     const seg = db.segments.get(segmentId);
     if (!seg) {
-      return NextResponse.json({ error: "Segment not found" }, { status: 422 });
+      return jsonError(422, "Segment not found");
     }
     if (seg.orgId !== orgId) {
-      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+      return jsonError(403, "Forbidden");
     }
   }
   const now = new Date().toISOString();

--- a/src/app/api/email/render/route.ts
+++ b/src/app/api/email/render/route.ts
@@ -1,27 +1,26 @@
-
-import { renderEmail, EmailBlock } from "@/lib/email/render"
+import { NextRequest, NextResponse } from "next/server";
+import { renderEmail, EmailBlock } from "@/lib/email/render";
+import { jsonError } from "@/lib/api";
 
 function applyVariables(html: string, variables: Record<string, string>): string {
   return Object.entries(variables || {}).reduce(
-    (acc, [key, value]) => acc.replace(new RegExp(`{{\\s*${key}\\s*}}`, "g"), String(value)),
+    (acc, [key, value]) =>
+      acc.replace(new RegExp(`{{\\s*${key}\\s*}}`, "g"), String(value)),
     html,
-  )
+  );
 }
 
-export async function POST(req: Request) {
+export async function POST(req: NextRequest) {
   try {
-    const { content_json, variables } = await req.json()
+    const { content_json, variables } = await req.json();
     const blocks: EmailBlock[] =
-      typeof content_json === "string" ? JSON.parse(content_json) : content_json
-    let html = renderEmail(blocks)
+      typeof content_json === "string" ? JSON.parse(content_json) : content_json;
+    let html = renderEmail(blocks);
     if (variables && typeof variables === "object") {
-      html = applyVariables(html, variables as Record<string, string>)
+      html = applyVariables(html, variables as Record<string, string>);
     }
-    return Response.json({ html })
+    return NextResponse.json({ html });
   } catch (err) {
-    return new Response(JSON.stringify({ error: "Invalid content_json" }), {
-      status: 400,
-      headers: { "Content-Type": "application/json" },
-    })
+    return jsonError(400, "Invalid content_json");
   }
 }

--- a/src/app/api/segments/[id]/members/route.ts
+++ b/src/app/api/segments/[id]/members/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { getSessionOrg } from "@/lib/auth";
+import { requireOrg, jsonError } from "@/lib/api";
 import { db } from "@/lib/store";
 
 const membersSchema = z.object({
@@ -11,24 +11,19 @@ export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const orgId = await getSessionOrg();
-  if (!orgId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const orgId = await requireOrg(req);
+  if (orgId instanceof NextResponse) return orgId;
   const segment = db.segments.get(params.id);
   if (!segment) {
-    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+    return jsonError(404, "Not Found");
   }
   if (segment.orgId !== orgId) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    return jsonError(403, "Forbidden");
   }
   const body = await req.json().catch(() => null);
   const parsed = membersSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten() },
-      { status: 422 }
-    );
+    return jsonError(422, parsed.error.flatten());
   }
   for (const id of parsed.data.contactIds) {
     if (!segment.members.includes(id)) segment.members.push(id);
@@ -41,24 +36,19 @@ export async function DELETE(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const orgId = await getSessionOrg();
-  if (!orgId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const orgId = await requireOrg(req);
+  if (orgId instanceof NextResponse) return orgId;
   const segment = db.segments.get(params.id);
   if (!segment) {
-    return NextResponse.json({ error: "Not Found" }, { status: 404 });
+    return jsonError(404, "Not Found");
   }
   if (segment.orgId !== orgId) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    return jsonError(403, "Forbidden");
   }
   const body = await req.json().catch(() => null);
   const parsed = membersSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten() },
-      { status: 422 }
-    );
+    return jsonError(422, parsed.error.flatten());
   }
   segment.members = segment.members.filter(
     (m) => !parsed.data.contactIds.includes(m)

--- a/src/app/api/segments/route.ts
+++ b/src/app/api/segments/route.ts
@@ -1,16 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { randomUUID } from "crypto";
-import { getSessionOrg } from "@/lib/auth";
+import { requireOrg, jsonError } from "@/lib/api";
 import { db, Segment } from "@/lib/store";
 
 const PAGE_SIZE = 10;
 
 export async function GET(req: NextRequest) {
-  const orgId = await getSessionOrg();
-  if (!orgId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const orgId = await requireOrg(req);
+  if (orgId instanceof NextResponse) return orgId;
   const { searchParams } = new URL(req.url);
   const cursor = searchParams.get("cursor") || undefined;
 
@@ -31,17 +29,12 @@ const createSchema = z.object({
 });
 
 export async function POST(req: NextRequest) {
-  const orgId = await getSessionOrg();
-  if (!orgId) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const orgId = await requireOrg(req);
+  if (orgId instanceof NextResponse) return orgId;
   const body = await req.json().catch(() => null);
   const parsed = createSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten() },
-      { status: 422 }
-    );
+    return jsonError(422, parsed.error.flatten());
   }
   const { name, dslJson } = parsed.data;
   const now = new Date().toISOString();

--- a/src/app/api/templates/[id]/content/route.ts
+++ b/src/app/api/templates/[id]/content/route.ts
@@ -1,36 +1,34 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { z } from 'zod'
-import { prisma } from '@/lib/prisma'
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { prisma } from "@/lib/prisma";
+import { jsonError } from "@/lib/api";
 
 const saveSchema = z.object({
   contentJson: z.any(),
   html: z.string(),
-})
+});
 
 export async function POST(
   req: NextRequest,
   { params }: { params: { id: string } }
 ) {
-  const body = await req.json().catch(() => null)
-  const parsed = saveSchema.safeParse(body)
+  const body = await req.json().catch(() => null);
+  const parsed = saveSchema.safeParse(body);
   if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten() },
-      { status: 422 }
-    )
+    return jsonError(422, parsed.error.flatten());
   }
 
-  const { contentJson, html } = parsed.data
-  const templateId = params.id
+  const { contentJson, html } = parsed.data;
+  const templateId = params.id;
 
   await prisma.emailTemplate.update({
     where: { id: templateId },
     data: { contentJson },
-  })
+  });
 
   await prisma.emailTemplateSnapshot.create({
     data: { templateId, html },
-  })
+  });
 
-  return NextResponse.json({ ok: true })
+  return NextResponse.json({ ok: true });
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSessionOrg } from "./auth";
+
+export function jsonError(status: number, message: unknown) {
+  return NextResponse.json({ error: message }, { status });
+}
+
+export async function requireOrg(_req: NextRequest): Promise<string | NextResponse> {
+  const orgId = await getSessionOrg();
+  if (!orgId) {
+    return jsonError(401, "Unauthorized");
+  }
+  return orgId;
+}


### PR DESCRIPTION
## Summary
- add `jsonError` and `requireOrg` helpers for API handlers
- refactor API routes to use helpers for org checks and errors

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7929bf320832d92afbaa891d500dd