### PR TITLE
feat: add help and search placeholders

### DIFF
--- a/src/app/help/page.tsx
+++ b/src/app/help/page.tsx
@@ -1,0 +1,3 @@
+export default function HelpPage() {
+  return <div className="p-6">Help content coming soon.</div>
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -1,0 +1,3 @@
+export default function SearchPage() {
+  return <div className="p-6">Search functionality coming soon.</div>
+}

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -16,6 +16,8 @@ import {
 import { NavMain } from "@/components/nav-main"
 import { NavSecondary } from "@/components/nav-secondary"
 import { NavUser } from "@/components/nav-user"
+import { GetHelpDialog } from "@/components/get-help-dialog"
+import { SearchDialog } from "@/components/search-dialog"
 import {
   Sidebar,
   SidebarContent,
@@ -41,12 +43,15 @@ const navMain = [
 ]
 
 export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
+  const [helpOpen, setHelpOpen] = React.useState(false)
+  const [searchOpen, setSearchOpen] = React.useState(false)
+
   const handleGetHelpClick = () => {
-    alert("Get Help functionality coming soon!")
+    setHelpOpen(true)
   }
 
   const handleSearchClick = () => {
-    alert("Search functionality coming soon!")
+    setSearchOpen(true)
   }
 
   const navSecondary = [
@@ -55,17 +60,21 @@ export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
   ]
 
   return (
-    <Sidebar collapsible="offcanvas" {...props}>
-      <SidebarHeader>
-        <div className="text-base font-semibold">{user.organization}</div>
-      </SidebarHeader>
-      <SidebarContent>
-        <NavMain items={navMain} />
-        <NavSecondary items={navSecondary} className="mt-auto" />
-      </SidebarContent>
-      <SidebarFooter>
-        <NavUser user={user} />
-      </SidebarFooter>
-    </Sidebar>
+    <>
+      <Sidebar collapsible="offcanvas" {...props}>
+        <SidebarHeader>
+          <div className="text-base font-semibold">{user.organization}</div>
+        </SidebarHeader>
+        <SidebarContent>
+          <NavMain items={navMain} />
+          <NavSecondary items={navSecondary} className="mt-auto" />
+        </SidebarContent>
+        <SidebarFooter>
+          <NavUser user={user} />
+        </SidebarFooter>
+      </Sidebar>
+      <GetHelpDialog open={helpOpen} onOpenChange={setHelpOpen} />
+      <SearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
+    </>
   )
 }

--- a/src/components/get-help-dialog.tsx
+++ b/src/components/get-help-dialog.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+
+export interface GetHelpDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function GetHelpDialog({ open, onOpenChange }: GetHelpDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Get Help</DialogTitle>
+        </DialogHeader>
+        <div className="text-sm text-muted-foreground">Help content coming soon.</div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+

--- a/src/components/search-dialog.tsx
+++ b/src/components/search-dialog.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+
+export interface SearchDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Search</DialogTitle>
+        </DialogHeader>
+        <div className="text-sm text-muted-foreground">Search functionality coming soon.</div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+


### PR DESCRIPTION
## Summary
- replace sidebar alerts with state-driven dialog components
- add placeholder dialogs and pages for Get Help and Search actions

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - @maily-to/core)*

------
https://chatgpt.com/codex/tasks/task_e_68a792a51a94832db9b227215616eece