### PR TITLE
feat(email): queue with retry and metrics

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "tailwind-merge": "^3.3.1",
     "vaul": "^1.1.2",
     "zod": "^4.0.17",
-    "nodemailer": "^6.9.13"
+    "nodemailer": "^6.9.13",
+    "bullmq": "^5.12.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/packages/emailer/README.md
+++ b/src/packages/emailer/README.md
@@ -1,13 +1,17 @@
 # Emailer Package
 
-Email templating utilities built around a simple queue. Messages are rendered
-per recipient on the server using the block based templating utilities in
-`@/lib/email/render` and are sent via [Nodemailer](https://nodemailer.com/).
+Email templating utilities built around a [BullMQ](https://docs.bullmq.io/)
+queue. Messages are rendered per recipient on the server using the block based
+templating utilities in `@/lib/email/render` and are sent via
+[Nodemailer](https://nodemailer.com/).
 
 ### Usage
 
 ```ts
-import { enqueueEmail } from "@/packages/emailer";
+import { enqueueEmail, startEmailWorker } from "@/packages/emailer";
+
+// Start a worker somewhere in your application bootstrap
+startEmailWorker();
 
 await enqueueEmail({
   to: "user@example.com",
@@ -23,8 +27,9 @@ await enqueueEmail({
 The `unsubscribe_url` variable is required and the rendered HTML must contain
 its value; otherwise an error is thrown.
 
-The queue currently sends immediately using Nodemailer's transport. If no
+Queued messages are processed asynchronously by a BullMQ worker. If no
 `SMTP_URL` environment variable is provided, a JSON transport is used for
 development/testing.
 
-Metrics collection hooks remain TODO.
+Optional metrics hooks can be registered with `registerEmailMetrics` for
+instrumentation.

--- a/src/packages/emailer/queue.ts
+++ b/src/packages/emailer/queue.ts
@@ -1,5 +1,9 @@
 import nodemailer from "nodemailer";
+import { Queue, Worker, QueueScheduler, type JobsOptions } from "bullmq";
 import { renderEmail, type EmailBlock } from "@/lib/email/render";
+
+/** Name of the BullMQ queue */
+const QUEUE_NAME = "emails";
 
 export interface QueuePayload {
   to: string;
@@ -18,6 +22,103 @@ export interface QueuePayload {
   variables: Record<string, string>;
 }
 
+/** Metrics hook interface allowing external instrumentation */
+export interface MetricsHook {
+  increment(metric: string, value?: number): void;
+}
+
+let metrics: MetricsHook | undefined;
+
+/** Register a metrics hook for instrumentation */
+export function registerEmailMetrics(hook: MetricsHook): void {
+  metrics = hook;
+}
+
+function log(
+  level: "info" | "error",
+  event: string,
+  meta: Record<string, unknown>
+) {
+  const payload = { event, ...meta };
+  if (level === "error") {
+    console.error(payload);
+  } else {
+    console.log(payload);
+  }
+}
+
+function redisConnection() {
+  const url = process.env.REDIS_URL || "redis://localhost:6379";
+  const { hostname, port } = new URL(url);
+  return { host: hostname, port: Number(port) };
+}
+
+let queue: Queue<QueuePayload> | undefined;
+let scheduler: QueueScheduler | undefined;
+
+function getQueue(): Queue<QueuePayload> {
+  if (!queue) {
+    const connection = redisConnection();
+    queue = new Queue<QueuePayload>(QUEUE_NAME, { connection });
+    scheduler = new QueueScheduler(QUEUE_NAME, { connection });
+  }
+  return queue;
+}
+
+export async function enqueueEmail(payload: QueuePayload): Promise<void> {
+  const jobOptions: JobsOptions = {
+    attempts: 3,
+    backoff: { type: "exponential", delay: 1000 },
+  };
+  await getQueue().add("send", payload, jobOptions);
+  log("info", "email.enqueued", { to: payload.to, subject: payload.subject });
+  metrics?.increment("email.enqueued");
+}
+
+let worker: Worker<QueuePayload> | undefined;
+
+/** Start a worker to process queued emails */
+export function startEmailWorker(): Worker<QueuePayload> {
+  if (!worker) {
+    const connection = redisConnection();
+    worker = new Worker<QueuePayload>(
+      QUEUE_NAME,
+      async (job) => {
+        const { to, subject, blocks, variables } = job.data;
+        if (!variables.unsubscribe_url) {
+          throw new Error("unsubscribe_url is required");
+        }
+        const html = renderWithVariables(blocks, variables);
+        if (!html.includes(variables.unsubscribe_url)) {
+          throw new Error("Rendered HTML must include unsubscribe_url");
+        }
+
+        const transporter = nodemailer.createTransport(
+          process.env.SMTP_URL ? process.env.SMTP_URL : { jsonTransport: true }
+        );
+
+        await transporter.sendMail({
+          from: process.env.EMAIL_FROM || "no-reply@example.com",
+          to,
+          subject,
+          html,
+        });
+
+        log("info", "email.sent", { jobId: job.id, to, subject });
+        metrics?.increment("email.sent");
+      },
+      { connection }
+    );
+
+    worker.on("failed", (job, err) => {
+      log("error", "email.failed", { jobId: job?.id, err: err.message });
+      metrics?.increment("email.failed");
+    });
+  }
+
+  return worker;
+}
+
 function renderWithVariables(
   blocks: EmailBlock[],
   variables: Record<string, string>
@@ -30,27 +131,3 @@ function renderWithVariables(
   return html;
 }
 
-export async function enqueueEmail(payload: QueuePayload): Promise<void> {
-  const { to, subject, blocks, variables } = payload;
-  if (!variables.unsubscribe_url) {
-    throw new Error("unsubscribe_url is required");
-  }
-  const html = renderWithVariables(blocks, variables);
-  if (!html.includes(variables.unsubscribe_url)) {
-    throw new Error("Rendered HTML must include unsubscribe_url");
-  }
-
-  const transporter = nodemailer.createTransport(
-    process.env.SMTP_URL ? process.env.SMTP_URL : { jsonTransport: true }
-  );
-
-  await transporter.sendMail({
-    from: process.env.EMAIL_FROM || "no-reply@example.com",
-    to,
-    subject,
-    html,
-  });
-
-  console.log("Enqueue email", { to, subject });
-  // TODO: record metrics
-}


### PR DESCRIPTION
## Summary
- integrate BullMQ-based queue to send emails asynchronously
- add retry logic, structured logging, and metrics hooks
- document usage and worker startup

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a792b24918832db2c5ab8d182e1c45