### PR TITLE
fix: separate client env

### DIFF
--- a/src/lib/env-client.ts
+++ b/src/lib/env-client.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
+});
+
+export const env = envSchema.parse({
+  NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+});

--- a/src/packages/db/client.ts
+++ b/src/packages/db/client.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
-import { env } from '@/lib/env';
+import { env } from '@/lib/env-client';
 
 const supabaseUrl = env.NEXT_PUBLIC_SUPABASE_URL;
 const supabaseAnonKey = env.NEXT_PUBLIC_SUPABASE_ANON_KEY;


### PR DESCRIPTION
## Summary
- add client-only env parsing so public variables can be used without server secrets
- update browser Supabase client to use client env

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden when fetching @maily-to/core)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ac68e0fc832d96f9300417bee020