### PR TITLE
Hide navigation sidebar on public pages

### DIFF
--- a/src/components/layout-wrapper.tsx
+++ b/src/components/layout-wrapper.tsx
@@ -1,10 +1,18 @@
 'use client'
 
 import type { ReactNode } from 'react'
+import { usePathname } from 'next/navigation'
 import { SidebarProvider } from '@/components/ui/sidebar'
 import { AppSidebar } from '@/components/app-sidebar'
 
 export function LayoutWrapper({ children }: { children: ReactNode }) {
+  const pathname = usePathname()
+  const publicRoutes = ['/', '/login', '/signup']
+
+  if (publicRoutes.includes(pathname)) {
+    return <>{children}</>
+  }
+
   return (
     <SidebarProvider>
       <div className="flex h-dvh w-full overflow-hidden">


### PR DESCRIPTION
## Summary
- only show the sidebar on protected routes

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b2f0474c832d82c9d97f99d5ce0a