### PR TITLE
refactor: update contacts segments flow

### DIFF
--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -10,8 +10,8 @@ export default function ContactsPage() {
     <SidebarInset>
       <SiteHeader title="Contacts" />
       <div className="p-4 space-y-8">
-        <ContactsDataTable data={contacts} />
         <SegmentsSection />
+        <ContactsDataTable data={contacts} />
       </div>
     </SidebarInset>
   )

--- a/src/components/segments/SegmentCard.tsx
+++ b/src/components/segments/SegmentCard.tsx
@@ -14,9 +14,9 @@ export function SegmentCard({ segment, onEdit }: SegmentCardProps) {
       <CardHeader>
         <CardTitle className="text-base font-medium">{segment.name || 'Untitled'}</CardTitle>
       </CardHeader>
-      {segment.subtitle && (
+      {segment.description && (
         <CardContent>
-          <p className="text-sm text-muted-foreground">{segment.subtitle}</p>
+          <p className="text-sm text-muted-foreground">{segment.description}</p>
         </CardContent>
       )}
     </Card>

--- a/src/components/segments/SegmentEditorDialog.tsx
+++ b/src/components/segments/SegmentEditorDialog.tsx
@@ -13,17 +13,15 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
 import { Separator } from '@/components/ui/separator'
-import { SegmentFiltersBuilder, SegmentFilter } from './SegmentFiltersBuilder'
+import { SegmentFiltersBuilder } from './SegmentFiltersBuilder'
 import { useAutosave } from '@/hooks/use-autosave'
 import { SegmentMembersTable } from './SegmentMembersTable'
 
 export interface SegmentDraft {
   id: string
   name: string
-  subtitle: string
+  description: string
   category: string
-  filtersMode: 'any' | 'all'
-  filters: SegmentFilter[]
   members: string[]
 }
 
@@ -59,10 +57,8 @@ export function SegmentEditorDialog({
   const empty: SegmentDraft = {
     id: '',
     name: '',
-    subtitle: '',
+    description: '',
     category: '',
-    filtersMode: 'any',
-    filters: [],
     members: [],
   }
   const { draft, setDraft, saving, savedAt } = useAutosave<SegmentDraft>({
@@ -77,7 +73,7 @@ export function SegmentEditorDialog({
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
       <DialogContent className="flex max-h-[90vh] flex-col gap-4">
         <DialogHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between pr-8">
             <DialogTitle>{draft.name || 'New Segment'}</DialogTitle>
             <AutosaveBadge saving={saving} savedAt={savedAt} />
           </div>
@@ -92,23 +88,15 @@ export function SegmentEditorDialog({
               onChange={(e) => setDraft({ ...draft, name: e.target.value })}
             />
             <Input
-              placeholder="Subtitle"
-              value={draft.subtitle}
-              onChange={(e) => setDraft({ ...draft, subtitle: e.target.value })}
+              placeholder="Description"
+              value={draft.description}
+              onChange={(e) => setDraft({ ...draft, description: e.target.value })}
             />
-            <Input
-              placeholder="Category"
+            <SegmentFiltersBuilder
               value={draft.category}
-              onChange={(e) => setDraft({ ...draft, category: e.target.value })}
+              onChange={(v) => setDraft({ ...draft, category: v })}
             />
           </div>
-          <Separator />
-          <SegmentFiltersBuilder
-            value={{ mode: draft.filtersMode, filters: draft.filters }}
-            onChange={(v) =>
-              setDraft({ ...draft, filtersMode: v.mode, filters: v.filters })
-            }
-          />
           <Separator />
           <SegmentMembersTable
             value={draft.members}
@@ -119,7 +107,7 @@ export function SegmentEditorDialog({
           <Button variant="outline" onClick={onClose}>
             Cancel
           </Button>
-          <Button onClick={() => onSave(draft)}>Save Segment</Button>
+          <Button onClick={() => onSave(draft)}>Create Segment</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/segments/SegmentEmptyCard.tsx
+++ b/src/components/segments/SegmentEmptyCard.tsx
@@ -2,13 +2,20 @@
 
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { PlusCircle } from 'lucide-react'
 
 export function SegmentEmptyCard({ onCreate }: { onCreate: () => void }) {
   return (
-    <Card className="flex h-full items-center justify-center" data-empty>
+    <Card className="mx-auto max-w-md border border-dashed" data-empty>
       <CardContent className="flex flex-col items-center justify-center gap-4 p-6 text-center">
-        <p className="text-sm text-muted-foreground">No segments yet</p>
-        <Button onClick={onCreate}>Create segment</Button>
+        <h3 className="text-base font-semibold">Create a segment</h3>
+        <p className="text-sm">No segments yet</p>
+        <p className="text-sm text-muted-foreground">
+          Filter your contacts for campaigns, reports, email lists, and more.
+        </p>
+        <Button onClick={onCreate}>
+          <PlusCircle className="mr-2 h-4 w-4" /> Create Segment
+        </Button>
       </CardContent>
     </Card>
   )

--- a/src/components/segments/SegmentFiltersBuilder.tsx
+++ b/src/components/segments/SegmentFiltersBuilder.tsx
@@ -1,93 +1,34 @@
 'use client'
 
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select'
-
-export type SegmentFilter = {
-  id: string
-  type: 'tag' | 'emailDomain' | 'date'
-  value: string
-}
-
-interface BuilderValue {
-  mode: 'any' | 'all'
-  filters: SegmentFilter[]
-}
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem, SelectSeparator } from '@/components/ui/select'
+import { Megaphone, BarChart, Mail, PlusCircle } from 'lucide-react'
 
 interface SegmentFiltersBuilderProps {
-  value: BuilderValue
-  onChange: (value: BuilderValue) => void
+  value: string
+  onChange: (value: string) => void
 }
 
 export function SegmentFiltersBuilder({ value, onChange }: SegmentFiltersBuilderProps) {
-  const { mode, filters } = value
-
-  function updateFilter(id: string, patch: Partial<SegmentFilter>) {
-    onChange({
-      mode,
-      filters: filters.map((f) => (f.id === id ? { ...f, ...patch } : f)),
-    })
-  }
-
   return (
-    <div className="space-y-4">
-      <Select value={mode} onValueChange={(v) => onChange({ mode: v as 'any' | 'all', filters })}>
-        <SelectTrigger className="w-32">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="any">Any</SelectItem>
-          <SelectItem value="all">All</SelectItem>
-        </SelectContent>
-      </Select>
-
-      <div className="space-y-2">
-        {filters.map((filter) => (
-          <div key={filter.id} className="flex items-center gap-2">
-            <Select
-              value={filter.type}
-              onValueChange={(v) => updateFilter(filter.id, { type: v as SegmentFilter['type'] })}
-            >
-              <SelectTrigger className="w-40">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="tag">Tag</SelectItem>
-                <SelectItem value="emailDomain">Email Domain</SelectItem>
-                <SelectItem value="date">Date</SelectItem>
-              </SelectContent>
-            </Select>
-            <Input
-              className="flex-1"
-              value={filter.value}
-              onChange={(e) => updateFilter(filter.id, { value: e.target.value })}
-              placeholder="Value"
-            />
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() =>
-                onChange({ mode, filters: filters.filter((f) => f.id !== filter.id) })
-              }
-            >
-              ×
-            </Button>
-          </div>
-        ))}
-      </div>
-
-      <Button
-        variant="outline"
-        onClick={() =>
-          onChange({
-            mode,
-            filters: [...filters, { id: Date.now().toString(), type: 'tag', value: '' }],
-          })
-        }
-      >
-        Add filter
-      </Button>
-    </div>
+    <Select value={value} onValueChange={onChange}>
+      <SelectTrigger className="w-40">
+        <SelectValue placeholder="Select" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="campaign">
+          <Megaphone className="mr-2 h-4 w-4" /> Campaign
+        </SelectItem>
+        <SelectItem value="report">
+          <BarChart className="mr-2 h-4 w-4" /> Report
+        </SelectItem>
+        <SelectItem value="email">
+          <Mail className="mr-2 h-4 w-4" /> Email lists
+        </SelectItem>
+        <SelectSeparator />
+        <SelectItem value="new">
+          <PlusCircle className="mr-2 h-4 w-4" /> Create new
+        </SelectItem>
+      </SelectContent>
+    </Select>
   )
 }

--- a/src/components/segments/SegmentsSection.tsx
+++ b/src/components/segments/SegmentsSection.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useState } from 'react'
+import { PlusCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { SegmentCard } from './SegmentCard'
 import { SegmentEmptyCard } from './SegmentEmptyCard'
 import { SegmentEditorDialog, SegmentDraft } from './SegmentEditorDialog'
@@ -19,41 +21,33 @@ export function SegmentsSection() {
     })
   }
 
+  function createNew() {
+    setEditing({
+      id: Date.now().toString(),
+      name: '',
+      description: '',
+      category: '',
+      members: [],
+    })
+  }
+
   return (
     <section className="space-y-4">
-      <h2 className="text-lg font-semibold">Segments</h2>
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Segments</h2>
+        {segments.length > 0 && (
+          <Button onClick={createNew}>
+            <PlusCircle className="mr-2 h-4 w-4" /> Create Segment
+          </Button>
+        )}
+      </div>
       {segments.length === 0 ? (
-        <SegmentEmptyCard
-          onCreate={() =>
-            setEditing({
-              id: Date.now().toString(),
-              name: '',
-              subtitle: '',
-              category: '',
-              filtersMode: 'any',
-              filters: [],
-              members: [],
-            })
-          }
-        />
+        <SegmentEmptyCard onCreate={createNew} />
       ) : (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {segments.map((segment) => (
             <SegmentCard key={segment.id} segment={segment} onEdit={() => setEditing(segment)} />
           ))}
-          <SegmentEmptyCard
-            onCreate={() =>
-              setEditing({
-                id: Date.now().toString(),
-                name: '',
-                subtitle: '',
-                category: '',
-                filtersMode: 'any',
-                filters: [],
-                members: [],
-              })
-            }
-          />
         </div>
       )}
       <SegmentEditorDialog

--- a/src/tests/components/autosave.test.tsx
+++ b/src/tests/components/autosave.test.tsx
@@ -9,10 +9,8 @@ describe('SegmentEditorDialog autosave', () => {
     const draft: SegmentDraft = {
       id: '1',
       name: '',
-      subtitle: '',
+      description: '',
       category: '',
-      filtersMode: 'any',
-      filters: [],
       members: [],
     }
     const onChange = vi.fn()

--- a/src/tests/components/filter-builder.test.tsx
+++ b/src/tests/components/filter-builder.test.tsx
@@ -1,31 +1,18 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { SegmentFiltersBuilder, SegmentFilter } from '@/components/segments/SegmentFiltersBuilder'
+import { SegmentFiltersBuilder } from '@/components/segments/SegmentFiltersBuilder'
 
 describe('SegmentFiltersBuilder', () => {
-  it('serializes builder state', async () => {
+  it('updates selection', async () => {
     const user = userEvent.setup()
-    let value = { mode: 'any' as const, filters: [] as SegmentFilter[] }
-    render(
-      <SegmentFiltersBuilder
-        value={value}
-        onChange={(v) => {
-          value = v
-        }}
-      />
-    )
+    let value = ''
+    render(<SegmentFiltersBuilder value={value} onChange={(v) => (value = v)} />)
 
-    await user.click(screen.getByText('Add filter'))
-    const input = screen.getByPlaceholderText('Value')
-    await user.type(input, 'VIP')
-
-    const trigger = screen.getByRole('combobox') // mode select
+    const trigger = screen.getByRole('combobox')
     await user.click(trigger)
-    await user.click(screen.getByText('All'))
+    await user.click(screen.getByText('Report'))
 
-    expect(() => JSON.stringify(value)).not.toThrow()
-    expect(value.mode).toBe('all')
-    expect(value.filters[0]).toMatchObject({ type: 'tag', value: 'VIP' })
+    expect(value).toBe('report')
   })
 })


### PR DESCRIPTION
## Summary
- place segments above contacts table
- redesign segment editor and placeholder card
- add category picker with icons and header create button

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: @maily-to/core forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b63779fc832da5a00ae1f8d8291a