### PR TITLE
fix: correct contacts data import path

### DIFF
--- a/src/components/segments/SegmentMembersTable.tsx
+++ b/src/components/segments/SegmentMembersTable.tsx
@@ -11,7 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
-import { contacts } from '@/app/contacts/data'
+import { contacts } from '@/app/(crm)/contacts/data'
 
 interface SegmentMembersTableProps {
   value: string[]


### PR DESCRIPTION
## Summary
- fix import path to contacts data module in SegmentMembersTable

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@maily-to%2fcore)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c8ee7ce4832d82c9f08b3b26045a