### PR TITLE
feat: add server-side Supabase helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ Create a `.env.local` file in the project root and add the following variables:
 ```env
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 DATABASE_URL=postgresql-connection-string
 ```
+
+These variables should also be added to your Vercel project as secrets so they're
+available at runtime.
 
 ### Set up the database
 

--- a/src/app/api/uploads/email-image/route.ts
+++ b/src/app/api/uploads/email-image/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
 import { randomUUID } from "crypto";
-import { getSessionOrg } from "@/lib/auth";
+import { requireOrg, jsonError } from "@/lib/api";
 import { env } from "@/lib/env";
+import { createSupabaseServer } from "@/packages/db";
 
 export async function POST(req: NextRequest) {
   const orgId = await requireOrg(req);
@@ -19,10 +19,7 @@ export async function POST(req: NextRequest) {
   const ext = file.name.split(".").pop();
   const key = `${orgId}/${randomUUID()}${ext ? `.${ext}` : ""}`;
 
-  const supabase = createClient(
-    env.NEXT_PUBLIC_SUPABASE_URL,
-    env.SUPABASE_SERVICE_ROLE_KEY
-  );
+  const supabase = createSupabaseServer();
   const bucket = env.SUPABASE_STORAGE_BUCKET;
 
   const { error } = await supabase.storage

--- a/src/packages/db/server.ts
+++ b/src/packages/db/server.ts
@@ -1,2 +1,10 @@
-// Placeholder for server-side Supabase utilities
-export {};
+import { createClient } from '@supabase/supabase-js';
+import { env } from '@/lib/env';
+
+/**
+ * Creates a Supabase client using the service role key.
+ * Intended for server-side API routes.
+ */
+export const createSupabaseServer = () =>
+  createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+


### PR DESCRIPTION
## Summary
- add `createSupabaseServer` helper for service-role Supabase client
- refactor email image upload API to use shared helper
- document `SUPABASE_SERVICE_ROLE_KEY` and Vercel secret setup

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon SUPABASE_SERVICE_ROLE_KEY=service SMTP_URL=smtp://example EMAIL_FROM=test@example.com npm test` *(fails: vitest not found)*
- `npm install` *(fails: missing peer dependency / private package)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c96daf30832d9db91177f1e0d2ac