### PR TITLE
Relax env variable requirements for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,11 @@ Create a `.env.local` file in the project root and add the following variables:
 ```env
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
-SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key # optional for local dev
 DATABASE_URL=postgresql-connection-string
+# Optional email configuration
+SMTP_URL=smtp://user:password@smtp.example.com
+EMAIL_FROM=no-reply@example.com
 ```
 
 These variables should also be added to your Vercel project as secrets so they're

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 const envSchema = z.object({
   NEXT_PUBLIC_SUPABASE_URL: z.string().url(),
   NEXT_PUBLIC_SUPABASE_ANON_KEY: z.string(),
-  SUPABASE_SERVICE_ROLE_KEY: z.string(),
-  SMTP_URL: z.string(),
-  EMAIL_FROM: z.string().email(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+  SMTP_URL: z.string().optional(),
+  EMAIL_FROM: z.string().email().optional(),
   SUPABASE_STORAGE_BUCKET: z.string().default("uploads"),
 });
 

--- a/src/packages/db/server.ts
+++ b/src/packages/db/server.ts
@@ -5,6 +5,10 @@ import { env } from '@/lib/env';
  * Creates a Supabase client using the service role key.
  * Intended for server-side API routes.
  */
-export const createSupabaseServer = () =>
-  createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+export const createSupabaseServer = () => {
+  if (!env.SUPABASE_SERVICE_ROLE_KEY)
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY is not set');
+
+  return createClient(env.NEXT_PUBLIC_SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY);
+};
 


### PR DESCRIPTION
## Summary
- allow SUPABASE service role and email env vars to be optional
- guard Supabase server client creation when service role key missing
- document optional env vars in README

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a90802a0e0832d84c0b8bf81b2b2bd