### PR TITLE
fix: avoid bundling server db code in client

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,4 @@
-export * from "@/packages/db";
+// Re-export only the browser client to avoid bundling server-side helpers
+// in the client build. Import server helpers directly where needed.
+export { createSupabaseBrowser } from "@/packages/db/client";
+


### PR DESCRIPTION
## Summary
- re-export only browser Supabase client to keep server helpers out of client bundle

## Testing
- `npm run lint` (fails: Unexpected any in multiple files)
- `npm test` (fails: Invalid PostCSS plugin in config)


------
https://chatgpt.com/codex/tasks/task_e_68b8516a2ca8832d98353dee4d71b478